### PR TITLE
Homemade timeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ TAGS
 /.stack-work-build/
 *.hie
 .idea
+*.iml
+*.code-workspace

--- a/install/Install.hs
+++ b/install/Install.hs
@@ -123,21 +123,16 @@ runShake pwd uid = shakeArgs options $ do
     cmd_ "terraform" ["destroy", "-auto-approve", "-var-file=infra/terraform.tfvars", "infra"]
 
   "ui/dist/index.html" %> \ _ -> do
-    need  ["ui/package-lock.json"]
     needDirectoryFiles
       "ui"
       [ "src//*.js",
         "src//*.html",
         "src//*.css",
+        "package.json",
         "webpack.config.js",
         ".babelrc"
       ]
     cmd (Cwd "ui") "npm" ["run", "build"]
-
-  "ui/package-lock.json" %> \ _ -> do
-    need [ "ui/package.json"]
-    cmd (Cwd "ui") "npm" ["i"]
-
 
 needDirectoryFiles dir patterns =
   need =<< getDirectoryFiles "" ((dir <>) <$> patterns)

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sensei-ui",
-  "version": "0.23.0",
+  "version": "0.18.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/ui/src/__snapshots__/css-notes.test.js.snap
+++ b/ui/src/__snapshots__/css-notes.test.js.snap
@@ -1,0 +1,438 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CSS Timeline expect notes to be drawn 1`] = `
+<body>
+  <div
+    id="main"
+  >
+    <div>
+      <div>
+        <div
+          class="timeline-header"
+          id="title-notes-2020-12-17"
+        >
+          Notes
+        </div>
+        <div
+          class="timeline-chart"
+          id="notes-2020-12-17"
+        >
+          <ul>
+            <li
+              style="width: 16px; margin-left: 192px;"
+            >
+              <div
+                aria-controls="note-2020-11-16T09:30:00"
+                aria-haspopup="dialog"
+                class="timeline-event timeline-note"
+                type="button"
+              />
+            </li>
+            <li
+              style="width: 16px; margin-left: 267.33333333333337px;"
+            >
+              <div
+                aria-controls="note-2020-11-16T10:55:00"
+                aria-haspopup="dialog"
+                class="timeline-event timeline-note"
+                type="button"
+              />
+            </li>
+            <li
+              style="width: 16px; margin-left: 267.33333333333337px;"
+            >
+              <div
+                aria-controls="note-2020-11-16T12:20:00"
+                aria-haspopup="dialog"
+                class="timeline-event timeline-note"
+                type="button"
+              />
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    aria-describedby="note-desc-2020-11-16T12:20:00"
+    aria-hidden="true"
+    aria-modal="true"
+    class="c-dialog"
+    id="note-2020-11-16T12:20:00"
+    role="[object HTMLDivElement]"
+    tabindex="-1"
+  >
+    <div
+      class="c-dialog__box"
+    >
+      <div
+        aria-dismiss="dialog"
+        aria-label="Close"
+        type="button"
+      >
+        X
+      </div>
+      <div
+        id="note-desc-2020-11-16T12:20:00"
+      >
+        <div
+          class="note"
+        >
+          <h4
+            id="202011161220"
+          >
+            2020-11-16 12:20
+          </h4>
+          
+
+          <h1
+            id="note"
+          >
+            Note
+          </h1>
+          
+
+          <h2
+            id="troisimenote"
+          >
+            Troisième note
+          </h2>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    aria-describedby="note-desc-2020-11-16T10:55:00"
+    aria-hidden="true"
+    aria-modal="true"
+    class="c-dialog"
+    id="note-2020-11-16T10:55:00"
+    role="[object HTMLDivElement]"
+    tabindex="-1"
+  >
+    <div
+      class="c-dialog__box"
+    >
+      <div
+        aria-dismiss="dialog"
+        aria-label="Close"
+        type="button"
+      >
+        X
+      </div>
+      <div
+        id="note-desc-2020-11-16T10:55:00"
+      >
+        <div
+          class="note"
+        >
+          <h4
+            id="202011161055"
+          >
+            2020-11-16 10:55
+          </h4>
+          
+
+          <h1
+            id="note"
+          >
+            Note
+          </h1>
+          
+
+          <h2
+            id="secondenote"
+          >
+            Seconde note
+          </h2>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    aria-describedby="note-desc-2020-11-16T09:30:00"
+    aria-hidden="true"
+    aria-modal="true"
+    class="c-dialog"
+    id="note-2020-11-16T09:30:00"
+    role="[object HTMLDivElement]"
+    tabindex="-1"
+  >
+    <div
+      class="c-dialog__box"
+    >
+      <div
+        aria-dismiss="dialog"
+        aria-label="Close"
+        type="button"
+      >
+        X
+      </div>
+      <div
+        id="note-desc-2020-11-16T09:30:00"
+      >
+        <div
+          class="note"
+        >
+          <h4
+            id="202011160930"
+          >
+            2020-11-16 09:30
+          </h4>
+          
+
+          <h1
+            id="note"
+          >
+            Note
+          </h1>
+          
+
+          <h2
+            id="premirenote"
+          >
+            Première note
+          </h2>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`CSS Timeline expect previous drawn notes to be removed 1`] = `
+<body>
+  <div
+    id="main"
+  >
+    <div>
+      <div>
+        <div
+          class="timeline-chart"
+          id="notes-2020-12-17"
+        >
+          <ul>
+            <li
+              style="width: 16px; margin-left: 192px;"
+            >
+              <div
+                aria-controls="note-2020-11-16T09:30:00"
+                aria-haspopup="dialog"
+                class="timeline-event timeline-note"
+                type="button"
+              />
+            </li>
+            <li
+              style="width: 16px; margin-left: 267.33333333333337px;"
+            >
+              <div
+                aria-controls="note-2020-11-16T10:55:00"
+                aria-haspopup="dialog"
+                class="timeline-event timeline-note"
+                type="button"
+              />
+            </li>
+            <li
+              style="width: 16px; margin-left: 267.33333333333337px;"
+            >
+              <div
+                aria-controls="note-2020-11-16T12:20:00"
+                aria-haspopup="dialog"
+                class="timeline-event timeline-note"
+                type="button"
+              />
+            </li>
+          </ul>
+        </div>
+        <div
+          class="timeline-header"
+          id="title-notes-2020-12-17"
+        >
+          Notes
+        </div>
+        <div
+          class="timeline-chart"
+          id="notes-2020-12-17"
+        >
+          <ul>
+            <li
+              style="width: 16px; margin-left: 192px;"
+            >
+              <div
+                aria-controls="note-2020-11-16T09:30:00"
+                aria-haspopup="dialog"
+                class="timeline-event timeline-note"
+                type="button"
+              />
+            </li>
+            <li
+              style="width: 16px; margin-left: 267.33333333333337px;"
+            >
+              <div
+                aria-controls="note-2020-11-16T10:55:00"
+                aria-haspopup="dialog"
+                class="timeline-event timeline-note"
+                type="button"
+              />
+            </li>
+            <li
+              style="width: 16px; margin-left: 267.33333333333337px;"
+            >
+              <div
+                aria-controls="note-2020-11-16T12:20:00"
+                aria-haspopup="dialog"
+                class="timeline-event timeline-note"
+                type="button"
+              />
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    aria-describedby="note-desc-2020-11-16T12:20:00"
+    aria-hidden="true"
+    aria-modal="true"
+    class="c-dialog"
+    id="note-2020-11-16T12:20:00"
+    role="[object HTMLDivElement]"
+    tabindex="-1"
+  >
+    <div
+      class="c-dialog__box"
+    >
+      <div
+        aria-dismiss="dialog"
+        aria-label="Close"
+        type="button"
+      >
+        X
+      </div>
+      <div
+        id="note-desc-2020-11-16T12:20:00"
+      >
+        <div
+          class="note"
+        >
+          <h4
+            id="202011161220"
+          >
+            2020-11-16 12:20
+          </h4>
+          
+
+          <h1
+            id="note"
+          >
+            Note
+          </h1>
+          
+
+          <h2
+            id="troisimenote"
+          >
+            Troisième note
+          </h2>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    aria-describedby="note-desc-2020-11-16T10:55:00"
+    aria-hidden="true"
+    aria-modal="true"
+    class="c-dialog"
+    id="note-2020-11-16T10:55:00"
+    role="[object HTMLDivElement]"
+    tabindex="-1"
+  >
+    <div
+      class="c-dialog__box"
+    >
+      <div
+        aria-dismiss="dialog"
+        aria-label="Close"
+        type="button"
+      >
+        X
+      </div>
+      <div
+        id="note-desc-2020-11-16T10:55:00"
+      >
+        <div
+          class="note"
+        >
+          <h4
+            id="202011161055"
+          >
+            2020-11-16 10:55
+          </h4>
+          
+
+          <h1
+            id="note"
+          >
+            Note
+          </h1>
+          
+
+          <h2
+            id="secondenote"
+          >
+            Seconde note
+          </h2>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    aria-describedby="note-desc-2020-11-16T09:30:00"
+    aria-hidden="true"
+    aria-modal="true"
+    class="c-dialog"
+    id="note-2020-11-16T09:30:00"
+    role="[object HTMLDivElement]"
+    tabindex="-1"
+  >
+    <div
+      class="c-dialog__box"
+    >
+      <div
+        aria-dismiss="dialog"
+        aria-label="Close"
+        type="button"
+      >
+        X
+      </div>
+      <div
+        id="note-desc-2020-11-16T09:30:00"
+      >
+        <div
+          class="note"
+        >
+          <h4
+            id="202011160930"
+          >
+            2020-11-16 09:30
+          </h4>
+          
+
+          <h1
+            id="note"
+          >
+            Note
+          </h1>
+          
+
+          <h2
+            id="premirenote"
+          >
+            Première note
+          </h2>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/ui/src/__snapshots__/css-timeline.test.js.snap
+++ b/ui/src/__snapshots__/css-timeline.test.js.snap
@@ -1,0 +1,2006 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CSS Timeline expect timeline not to clear notes 1`] = `
+<div>
+  <div
+    id="timeline-container-2020-12-17"
+  >
+    <div
+      class="timeline-flows"
+      id="timeline-flows-2020-12-17"
+    >
+      <ul>
+        <li
+          style="width: 100px; margin-left: 100px;"
+        >
+          <div>
+            <h2>
+              08:30
+            </h2>
+            <h2>
+              09:00
+            </h2>
+            <h3>
+              Flowing
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 100px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              09:00
+            </h2>
+            <h2>
+              09:30
+            </h2>
+            <h3>
+              Daily
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 150px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              09:30
+            </h2>
+            <h2>
+              10:15
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 350px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              10:15
+            </h2>
+            <h2>
+              12:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 333.33333333333337px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              12:00
+            </h2>
+            <h2>
+              13:40
+            </h2>
+            <h3>
+              Other
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 66.66666666666666px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              13:40
+            </h2>
+            <h2>
+              14:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 200px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              14:00
+            </h2>
+            <h2>
+              15:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 400px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              15:00
+            </h2>
+            <h2>
+              17:00
+            </h2>
+            <h3>
+              Rework
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 0px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              17:00
+            </h2>
+            <h2>
+              17:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-chart"
+      id="notes-2020-12-17"
+    >
+      <ul>
+        <li
+          style="width: 16px; margin-left: 292px;"
+        >
+          <div
+            aria-controls="note-2020-11-16T09:30:00"
+            aria-haspopup="dialog"
+            class="timeline-event timeline-note"
+            type="button"
+          />
+        </li>
+        <li
+          style="width: 16px; margin-left: 267.33333333333337px;"
+        >
+          <div
+            aria-controls="note-2020-11-16T10:55:00"
+            aria-haspopup="dialog"
+            class="timeline-event timeline-note"
+            type="button"
+          />
+        </li>
+        <li
+          style="width: 16px; margin-left: 267.33333333333337px;"
+        >
+          <div
+            aria-controls="note-2020-11-16T12:20:00"
+            aria-haspopup="dialog"
+            class="timeline-event timeline-note"
+            type="button"
+          />
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-header"
+    >
+      <div>
+        <h3>
+          Flowing
+        </h3>
+      </div>
+    </div>
+    <div
+      class="timeline-events"
+    >
+      <ul>
+        <li
+          style="width: 100px; margin-left: 100px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(0, 221, 34);"
+          />
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-header"
+    >
+      <div>
+        <h3>
+          Daily
+        </h3>
+      </div>
+    </div>
+    <div
+      class="timeline-events"
+    >
+      <ul>
+        <li
+          style="width: 100px; margin-left: 200px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 255, 255);"
+          />
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-header"
+    >
+      <div>
+        <h3>
+          Meeting
+        </h3>
+      </div>
+    </div>
+    <div
+      class="timeline-events"
+    >
+      <ul>
+        <li
+          style="width: 150px; margin-left: 300px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 350px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 66.66666666666666px; margin-left: 333.33333333333337px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 200px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 0px; margin-left: 400px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-header"
+    >
+      <div>
+        <h3>
+          Other
+        </h3>
+      </div>
+    </div>
+    <div
+      class="timeline-events"
+    >
+      <ul>
+        <li
+          style="width: 333.33333333333337px; margin-left: 800px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(51, 255, 212);"
+          />
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-header"
+    >
+      <div>
+        <h3>
+          Rework
+        </h3>
+      </div>
+    </div>
+    <div
+      class="timeline-events"
+    >
+      <ul>
+        <li
+          style="width: 400px; margin-left: 1400px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(69, 0, 221);"
+          />
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-time"
+      id="timeline-time-2020-12-17"
+    >
+      <ul>
+        <li>
+          08:00
+        </li>
+        <li>
+          08:30
+        </li>
+        <li>
+          09:00
+        </li>
+        <li>
+          09:30
+        </li>
+        <li>
+          10:00
+        </li>
+        <li>
+          10:30
+        </li>
+        <li>
+          11:00
+        </li>
+        <li>
+          11:30
+        </li>
+        <li>
+          12:00
+        </li>
+        <li>
+          12:30
+        </li>
+        <li>
+          13:00
+        </li>
+        <li>
+          13:30
+        </li>
+        <li>
+          14:00
+        </li>
+        <li>
+          14:30
+        </li>
+        <li>
+          15:00
+        </li>
+        <li>
+          15:30
+        </li>
+        <li>
+          16:00
+        </li>
+        <li>
+          16:30
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CSS Timeline expect timeline to be drawn 1`] = `
+<div>
+  <div
+    id="timeline-container-2020-12-17"
+  >
+    <div
+      class="timeline-flows"
+      id="timeline-flows-2020-12-17"
+    >
+      <ul>
+        <li
+          style="width: 100px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              08:30
+            </h2>
+            <h2>
+              09:00
+            </h2>
+            <h3>
+              Flowing
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 100px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              09:00
+            </h2>
+            <h2>
+              09:30
+            </h2>
+            <h3>
+              Daily
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 150px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              09:30
+            </h2>
+            <h2>
+              10:15
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 350px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              10:15
+            </h2>
+            <h2>
+              12:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 333.33333333333337px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              12:00
+            </h2>
+            <h2>
+              13:40
+            </h2>
+            <h3>
+              Other
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 66.66666666666666px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              13:40
+            </h2>
+            <h2>
+              14:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 200px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              14:00
+            </h2>
+            <h2>
+              15:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 400px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              15:00
+            </h2>
+            <h2>
+              17:00
+            </h2>
+            <h3>
+              Rework
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 0px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              17:00
+            </h2>
+            <h2>
+              17:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-header"
+    >
+      <div>
+        <h3>
+          2020-12-17
+        </h3>
+      </div>
+    </div>
+    <div
+      class="timeline-events"
+    >
+      <ul>
+        <li
+          style="width: 100px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(0, 221, 34);"
+          />
+        </li>
+        <li
+          style="width: 100px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 255, 255);"
+          />
+        </li>
+        <li
+          style="width: 150px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 350px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 333.33333333333337px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(51, 255, 212);"
+          />
+        </li>
+        <li
+          style="width: 66.66666666666666px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 200px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 400px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(69, 0, 221);"
+          />
+        </li>
+        <li
+          style="width: 0px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-time"
+      id="timeline-time-2020-12-17"
+    >
+      <ul>
+        <li>
+          08:30
+        </li>
+        <li>
+          09:00
+        </li>
+        <li>
+          09:30
+        </li>
+        <li>
+          10:00
+        </li>
+        <li>
+          10:30
+        </li>
+        <li>
+          11:00
+        </li>
+        <li>
+          11:30
+        </li>
+        <li>
+          12:00
+        </li>
+        <li>
+          12:30
+        </li>
+        <li>
+          13:00
+        </li>
+        <li>
+          13:30
+        </li>
+        <li>
+          14:00
+        </li>
+        <li>
+          14:30
+        </li>
+        <li>
+          15:00
+        </li>
+        <li>
+          15:30
+        </li>
+        <li>
+          16:00
+        </li>
+        <li>
+          16:30
+        </li>
+        <li>
+          17:00
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CSS Timeline expect timeline to be drawn with negative left margin when flow start before user start of day 1`] = `
+<div>
+  <div
+    id="timeline-container-2020-12-17"
+  >
+    <div
+      class="timeline-flows"
+      id="timeline-flows-2020-12-17"
+    >
+      <ul>
+        <li
+          style="width: 100px; margin-left: -100px;"
+        >
+          <div>
+            <h2>
+              08:30
+            </h2>
+            <h2>
+              09:00
+            </h2>
+            <h3>
+              Flowing
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 100px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              09:00
+            </h2>
+            <h2>
+              09:30
+            </h2>
+            <h3>
+              Daily
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 150px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              09:30
+            </h2>
+            <h2>
+              10:15
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 350px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              10:15
+            </h2>
+            <h2>
+              12:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 333.33333333333337px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              12:00
+            </h2>
+            <h2>
+              13:40
+            </h2>
+            <h3>
+              Other
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 66.66666666666666px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              13:40
+            </h2>
+            <h2>
+              14:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 200px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              14:00
+            </h2>
+            <h2>
+              15:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 400px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              15:00
+            </h2>
+            <h2>
+              17:00
+            </h2>
+            <h3>
+              Rework
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 0px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              17:00
+            </h2>
+            <h2>
+              17:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-header"
+    >
+      <div>
+        <h3>
+          2020-12-17
+        </h3>
+      </div>
+    </div>
+    <div
+      class="timeline-events"
+    >
+      <ul>
+        <li
+          style="width: 100px; margin-left: -100px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(0, 221, 34);"
+          />
+        </li>
+        <li
+          style="width: 100px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 255, 255);"
+          />
+        </li>
+        <li
+          style="width: 150px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 350px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 333.33333333333337px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(51, 255, 212);"
+          />
+        </li>
+        <li
+          style="width: 66.66666666666666px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 200px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 400px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(69, 0, 221);"
+          />
+        </li>
+        <li
+          style="width: 0px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-time"
+      id="timeline-time-2020-12-17"
+    >
+      <ul>
+        <li>
+          09:00
+        </li>
+        <li>
+          09:30
+        </li>
+        <li>
+          10:00
+        </li>
+        <li>
+          10:30
+        </li>
+        <li>
+          11:00
+        </li>
+        <li>
+          11:30
+        </li>
+        <li>
+          12:00
+        </li>
+        <li>
+          12:30
+        </li>
+        <li>
+          13:00
+        </li>
+        <li>
+          13:30
+        </li>
+        <li>
+          14:00
+        </li>
+        <li>
+          14:30
+        </li>
+        <li>
+          15:00
+        </li>
+        <li>
+          15:30
+        </li>
+        <li>
+          16:00
+        </li>
+        <li>
+          16:30
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CSS Timeline expect timeline to be drawn with positive left margin when flow start after user start of day 1`] = `
+<div>
+  <div
+    id="timeline-container-2020-12-17"
+  >
+    <div
+      class="timeline-flows"
+      id="timeline-flows-2020-12-17"
+    >
+      <ul>
+        <li
+          style="width: 100px; margin-left: 100px;"
+        >
+          <div>
+            <h2>
+              08:30
+            </h2>
+            <h2>
+              09:00
+            </h2>
+            <h3>
+              Flowing
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 100px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              09:00
+            </h2>
+            <h2>
+              09:30
+            </h2>
+            <h3>
+              Daily
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 150px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              09:30
+            </h2>
+            <h2>
+              10:15
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 350px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              10:15
+            </h2>
+            <h2>
+              12:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 333.33333333333337px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              12:00
+            </h2>
+            <h2>
+              13:40
+            </h2>
+            <h3>
+              Other
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 66.66666666666666px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              13:40
+            </h2>
+            <h2>
+              14:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 200px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              14:00
+            </h2>
+            <h2>
+              15:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 400px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              15:00
+            </h2>
+            <h2>
+              17:00
+            </h2>
+            <h3>
+              Rework
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 0px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              17:00
+            </h2>
+            <h2>
+              17:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-header"
+    >
+      <div>
+        <h3>
+          2020-12-17
+        </h3>
+      </div>
+    </div>
+    <div
+      class="timeline-events"
+    >
+      <ul>
+        <li
+          style="width: 100px; margin-left: 100px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(0, 221, 34);"
+          />
+        </li>
+        <li
+          style="width: 100px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 255, 255);"
+          />
+        </li>
+        <li
+          style="width: 150px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 350px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 333.33333333333337px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(51, 255, 212);"
+          />
+        </li>
+        <li
+          style="width: 66.66666666666666px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 200px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 400px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(69, 0, 221);"
+          />
+        </li>
+        <li
+          style="width: 0px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-time"
+      id="timeline-time-2020-12-17"
+    >
+      <ul>
+        <li>
+          08:00
+        </li>
+        <li>
+          08:30
+        </li>
+        <li>
+          09:00
+        </li>
+        <li>
+          09:30
+        </li>
+        <li>
+          10:00
+        </li>
+        <li>
+          10:30
+        </li>
+        <li>
+          11:00
+        </li>
+        <li>
+          11:30
+        </li>
+        <li>
+          12:00
+        </li>
+        <li>
+          12:30
+        </li>
+        <li>
+          13:00
+        </li>
+        <li>
+          13:30
+        </li>
+        <li>
+          14:00
+        </li>
+        <li>
+          14:30
+        </li>
+        <li>
+          15:00
+        </li>
+        <li>
+          15:30
+        </li>
+        <li>
+          16:00
+        </li>
+        <li>
+          16:30
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CSS Timeline expect timeline to be expand at selected date 1`] = `
+<div>
+  <div
+    id="timeline-container-2020-12-17"
+  >
+    <div
+      class="timeline-flows"
+      id="timeline-flows-2020-12-17"
+    >
+      <ul>
+        <li
+          style="width: 100px; margin-left: 100px;"
+        >
+          <div>
+            <h2>
+              08:30
+            </h2>
+            <h2>
+              09:00
+            </h2>
+            <h3>
+              Flowing
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 100px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              09:00
+            </h2>
+            <h2>
+              09:30
+            </h2>
+            <h3>
+              Daily
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 150px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              09:30
+            </h2>
+            <h2>
+              10:15
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 350px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              10:15
+            </h2>
+            <h2>
+              12:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 333.33333333333337px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              12:00
+            </h2>
+            <h2>
+              13:40
+            </h2>
+            <h3>
+              Other
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 66.66666666666666px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              13:40
+            </h2>
+            <h2>
+              14:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 200px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              14:00
+            </h2>
+            <h2>
+              15:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 400px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              15:00
+            </h2>
+            <h2>
+              17:00
+            </h2>
+            <h3>
+              Rework
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 0px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              17:00
+            </h2>
+            <h2>
+              17:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-header"
+    >
+      <div>
+        <h3>
+          Flowing
+        </h3>
+      </div>
+    </div>
+    <div
+      class="timeline-events"
+    >
+      <ul>
+        <li
+          style="width: 100px; margin-left: 100px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(0, 221, 34);"
+          />
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-header"
+    >
+      <div>
+        <h3>
+          Daily
+        </h3>
+      </div>
+    </div>
+    <div
+      class="timeline-events"
+    >
+      <ul>
+        <li
+          style="width: 100px; margin-left: 200px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 255, 255);"
+          />
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-header"
+    >
+      <div>
+        <h3>
+          Meeting
+        </h3>
+      </div>
+    </div>
+    <div
+      class="timeline-events"
+    >
+      <ul>
+        <li
+          style="width: 150px; margin-left: 300px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 350px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 66.66666666666666px; margin-left: 333.33333333333337px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 200px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 0px; margin-left: 400px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-header"
+    >
+      <div>
+        <h3>
+          Other
+        </h3>
+      </div>
+    </div>
+    <div
+      class="timeline-events"
+    >
+      <ul>
+        <li
+          style="width: 333.33333333333337px; margin-left: 800px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(51, 255, 212);"
+          />
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-header"
+    >
+      <div>
+        <h3>
+          Rework
+        </h3>
+      </div>
+    </div>
+    <div
+      class="timeline-events"
+    >
+      <ul>
+        <li
+          style="width: 400px; margin-left: 1400px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(69, 0, 221);"
+          />
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-time"
+      id="timeline-time-2020-12-17"
+    >
+      <ul>
+        <li>
+          08:00
+        </li>
+        <li>
+          08:30
+        </li>
+        <li>
+          09:00
+        </li>
+        <li>
+          09:30
+        </li>
+        <li>
+          10:00
+        </li>
+        <li>
+          10:30
+        </li>
+        <li>
+          11:00
+        </li>
+        <li>
+          11:30
+        </li>
+        <li>
+          12:00
+        </li>
+        <li>
+          12:30
+        </li>
+        <li>
+          13:00
+        </li>
+        <li>
+          13:30
+        </li>
+        <li>
+          14:00
+        </li>
+        <li>
+          14:30
+        </li>
+        <li>
+          15:00
+        </li>
+        <li>
+          15:30
+        </li>
+        <li>
+          16:00
+        </li>
+        <li>
+          16:30
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CSS Timeline expect timeline to have row label with flowtype after being drawn without 1`] = `
+<div>
+  <div
+    id="timeline-container-2020-12-17"
+  >
+    <div
+      class="timeline-flows"
+      id="timeline-flows-2020-12-17"
+    >
+      <ul>
+        <li
+          style="width: 100px; margin-left: 100px;"
+        >
+          <div>
+            <h2>
+              08:30
+            </h2>
+            <h2>
+              09:00
+            </h2>
+            <h3>
+              Flowing
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 100px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              09:00
+            </h2>
+            <h2>
+              09:30
+            </h2>
+            <h3>
+              Daily
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 150px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              09:30
+            </h2>
+            <h2>
+              10:15
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 350px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              10:15
+            </h2>
+            <h2>
+              12:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 333.33333333333337px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              12:00
+            </h2>
+            <h2>
+              13:40
+            </h2>
+            <h3>
+              Other
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 66.66666666666666px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              13:40
+            </h2>
+            <h2>
+              14:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 200px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              14:00
+            </h2>
+            <h2>
+              15:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 400px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              15:00
+            </h2>
+            <h2>
+              17:00
+            </h2>
+            <h3>
+              Rework
+            </h3>
+          </div>
+        </li>
+        <li
+          style="width: 0px; margin-left: 0px;"
+        >
+          <div>
+            <h2>
+              17:00
+            </h2>
+            <h2>
+              17:00
+            </h2>
+            <h3>
+              Meeting
+            </h3>
+          </div>
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-header"
+    >
+      <div>
+        <h3>
+          Flowing
+        </h3>
+      </div>
+    </div>
+    <div
+      class="timeline-events"
+    >
+      <ul>
+        <li
+          style="width: 100px; margin-left: 100px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(0, 221, 34);"
+          />
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-header"
+    >
+      <div>
+        <h3>
+          Daily
+        </h3>
+      </div>
+    </div>
+    <div
+      class="timeline-events"
+    >
+      <ul>
+        <li
+          style="width: 100px; margin-left: 200px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 255, 255);"
+          />
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-header"
+    >
+      <div>
+        <h3>
+          Meeting
+        </h3>
+      </div>
+    </div>
+    <div
+      class="timeline-events"
+    >
+      <ul>
+        <li
+          style="width: 150px; margin-left: 300px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 350px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 66.66666666666666px; margin-left: 333.33333333333337px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 200px; margin-left: 0px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+        <li
+          style="width: 0px; margin-left: 400px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(255, 242, 3);"
+          />
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-header"
+    >
+      <div>
+        <h3>
+          Other
+        </h3>
+      </div>
+    </div>
+    <div
+      class="timeline-events"
+    >
+      <ul>
+        <li
+          style="width: 333.33333333333337px; margin-left: 800px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(51, 255, 212);"
+          />
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-header"
+    >
+      <div>
+        <h3>
+          Rework
+        </h3>
+      </div>
+    </div>
+    <div
+      class="timeline-events"
+    >
+      <ul>
+        <li
+          style="width: 400px; margin-left: 1400px;"
+        >
+          <div
+            class="timeline-event"
+            style="background: rgb(69, 0, 221);"
+          />
+        </li>
+      </ul>
+    </div>
+    <div
+      class="timeline-time"
+      id="timeline-time-2020-12-17"
+    >
+      <ul>
+        <li>
+          08:00
+        </li>
+        <li>
+          08:30
+        </li>
+        <li>
+          09:00
+        </li>
+        <li>
+          09:30
+        </li>
+        <li>
+          10:00
+        </li>
+        <li>
+          10:30
+        </li>
+        <li>
+          11:00
+        </li>
+        <li>
+          11:30
+        </li>
+        <li>
+          12:00
+        </li>
+        <li>
+          12:30
+        </li>
+        <li>
+          13:00
+        </li>
+        <li>
+          13:30
+        </li>
+        <li>
+          14:00
+        </li>
+        <li>
+          14:30
+        </li>
+        <li>
+          15:00
+        </li>
+        <li>
+          15:30
+        </li>
+        <li>
+          16:00
+        </li>
+        <li>
+          16:30
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;

--- a/ui/src/__snapshots__/notes.test.js.snap
+++ b/ui/src/__snapshots__/notes.test.js.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Notes it should display note date like 2020-10-12 14:30 1`] = `
+<div>
+  <div
+    class="pagination"
+  >
+    <button
+      class="btn-prev"
+      disabled=""
+    >
+      &lt;&lt;
+    </button>
+    <button
+      class="btn-next"
+      disabled=""
+    >
+      &gt;&gt;
+    </button>
+  </div>
+  <div
+    id="notes-list"
+  >
+    <h2>
+      Notes for 
+      1
+       
+    </h2>
+    <div
+      class="note-full"
+    >
+      <h3>
+        2020-10-12 14:30
+         
+      </h3>
+      <div
+        class="note-content"
+      >
+        <p>
+          content
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/ui/src/css-notes.js
+++ b/ui/src/css-notes.js
@@ -1,0 +1,46 @@
+import {dom} from './dom.js';
+import {ChronoUnit, LocalDateTime, LocalTime} from "@js-joda/core";
+import {config} from "./config";
+import showdown from "showdown";
+
+const THIRTY_MINUTES = 30;
+const HALF_HOUR_WIDTH = 100;
+
+export function drawCssNotes(container, day, notesData) {
+    let previousTime = LocalTime.parse(config.userProfile.userStartOfDay);
+
+    const timelineContainer = container.firstChild;
+    const notesDiv = <div id={'notes-' + day} class="timeline-chart" />;
+    const noteList = <ul />;
+
+    function formatNote(note) {
+        return "<div class='note'>" +
+            new showdown.Converter({ simplifiedAutoLink: true }).makeHtml('#### ' + new Date(note.noteStart).toLocaleTimeString() + '\n\n' + note.noteContent) +
+            "</div>";
+    }
+
+    function noteLeftMargin(note) {
+        let bulletGap = 8;
+        if(note !== notesData[0]) {
+            previousTime = LocalDateTime.parse(notesData[notesData.indexOf(note) - 1].noteStart);
+            bulletGap = 16;
+        }
+        return (previousTime.until(LocalDateTime.parse(note.noteStart), ChronoUnit.MINUTES) / THIRTY_MINUTES) * HALF_HOUR_WIDTH - bulletGap;
+    }
+
+    function drawTimelineFlow(note) {
+        // let flowStartDate = LocalDateTime.parse(note.noteStart);
+        return <li style={'width:16px; margin-left:' + noteLeftMargin(note) + 'px;'}>
+            <div class='timeline-event' style={'background: blue;'}></div>
+        </li>;
+
+    }
+
+    notesData.forEach(note => {
+        noteList.appendChild(drawTimelineFlow(note));
+    });
+
+    notesDiv.appendChild(noteList);
+    timelineContainer.insertBefore(notesDiv, timelineContainer.children[1]);
+
+}

--- a/ui/src/css-notes.js
+++ b/ui/src/css-notes.js
@@ -2,6 +2,7 @@ import {dom} from './dom.js';
 import {ChronoUnit, LocalDateTime, LocalTime} from "@js-joda/core";
 import {config} from "./config";
 import showdown from "showdown";
+import {formatISODateTime} from "./date";
 
 const THIRTY_MINUTES = 30;
 const HALF_HOUR_WIDTH = 100;
@@ -12,9 +13,13 @@ export function drawCssNotes(container, day, notesData) {
     const mainParentNode = mainNode.parentNode;
 
     const timelineContainer = container.firstChild;
+    const notesHeader = <div id={'title-notes-' + day} class="timeline-header">Notes</div>;
     const notesDiv = <div id={'notes-' + day} class="timeline-chart"/>;
     const noteList = <ul/>;
 
+    if(document.getElementById('title-notes-' + day)) {
+        document.getElementById('title-notes-' + day).remove();
+    }
     notesData.map(note => document.getElementById('note-' + note.noteStart))
         .filter(node => node !== null)
         .forEach(node => node.remove());
@@ -24,15 +29,16 @@ export function drawCssNotes(container, day, notesData) {
     });
 
     notesDiv.appendChild(noteList);
-    timelineContainer.insertBefore(notesDiv, timelineContainer.children[1]);
+    timelineContainer.insertBefore(notesHeader, timelineContainer.children[1]);
+    timelineContainer.insertBefore(notesDiv, timelineContainer.children[2]);
 
     function drawTimelineFlow(note) {
         const noteDisplay = <li style={'width:16px; margin-left:' + noteLeftMargin(note) + 'px;'}/>;
         const dialog = <div id={'note-' + note.noteStart} class="c-dialog"/>;
         const dialogBox = <div role="document" class="c-dialog__box"/>;
-        const closeButton = <div>Close</div>;
+        const closeButton = <div>X</div>;
         const dialogContent = <div id={'note-desc-' + note.noteStart}/>;
-        const button = <div type="button" class='timeline-event' style={'background: blue;'}/>;
+        const button = <div type="button"/>;
 
         noteDisplay.appendChild(button);
         dialog.appendChild(dialogBox);
@@ -62,7 +68,8 @@ export function drawCssNotes(container, day, notesData) {
         setAttributesTo(button, [
             {type: "type", value: "button"},
             {type: "aria-haspopup", value: "dialog"},
-            {type: "aria-controls", value: 'note-' + note.noteStart}
+            {type: "aria-controls", value: 'note-' + note.noteStart},
+            {type: "class", value: "timeline-event timeline-note"}
         ])
 
         initializeModal(dialog, button, closeButton);
@@ -72,7 +79,7 @@ export function drawCssNotes(container, day, notesData) {
 
     function formatNote(note) {
         return "<div class='note'>" +
-            new showdown.Converter({simplifiedAutoLink: true}).makeHtml('#### ' + new Date(note.noteStart).toLocaleTimeString() + '\n\n' + note.noteContent) +
+            new showdown.Converter({simplifiedAutoLink: true}).makeHtml('#### ' + formatISODateTime(LocalDateTime.parse(note.noteStart)) + '\n\n' + note.noteContent) +
             "</div>";
     }
 

--- a/ui/src/css-notes.test.js
+++ b/ui/src/css-notes.test.js
@@ -17,18 +17,38 @@ const notes = [{
 
 describe('CSS Timeline', () => {
 
+    let mainContainer;
+    let container;
+
     beforeEach(() => {
         config.userProfile = {};
+        container = document.createElement("div");
+        mainContainer = <div id="main" />;
+        container.appendChild(<div/>);
+        mainContainer.appendChild(container);
+        document.body.appendChild(mainContainer);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(mainContainer);
     });
 
     test('expect notes to be drawn', () => {
         config.userProfile.userStartOfDay = '08:30:00';
         config.userProfile.userEndOfDay = '17:00:00';
-        let container = document.createElement("div");
-        container.appendChild(<div/>);
 
         drawCssNotes(container, '2020-12-17', notes);
 
-        expect(container).toMatchSnapshot();
-    })
+        expect(document.body).toMatchSnapshot();
+    });
+
+    test('expect previous drawn notes to be removed', () => {
+        config.userProfile.userStartOfDay = '08:30:00';
+        config.userProfile.userEndOfDay = '17:00:00';
+
+        drawCssNotes(container, '2020-12-17', notes);
+        drawCssNotes(container, '2020-12-17', notes);
+
+        expect(document.body).toMatchSnapshot();
+    });
 });

--- a/ui/src/css-notes.test.js
+++ b/ui/src/css-notes.test.js
@@ -1,0 +1,34 @@
+import {dom} from './dom.js';
+import {config} from "./config";
+
+import {describe, expect, test} from '@jest/globals';
+import {drawCssNotes} from "./css-notes";
+
+const notes = [{
+    "noteStart": "2020-11-16T09:30:00",
+    "noteContent": "# Note\r## Première note"
+}, {
+    "noteStart": "2020-11-16T10:55:00",
+    "noteContent": "# Note\r## Seconde note"
+}, {
+    "noteStart": "2020-11-16T12:20:00",
+    "noteContent": "# Note\r## Troisième note"
+}];
+
+describe('CSS Timeline', () => {
+
+    beforeEach(() => {
+        config.userProfile = {};
+    });
+
+    test('expect notes to be drawn', () => {
+        config.userProfile.userStartOfDay = '08:30:00';
+        config.userProfile.userEndOfDay = '17:00:00';
+        let container = document.createElement("div");
+        container.appendChild(<div/>);
+
+        drawCssNotes(container, '2020-12-17', notes);
+
+        expect(container).toMatchSnapshot();
+    })
+});

--- a/ui/src/css-timeline.js
+++ b/ui/src/css-timeline.js
@@ -1,18 +1,19 @@
 import {dom} from './dom.js';
 import {colorOf} from './color.js';
+import { config } from "./config";
 import {ChronoUnit, DateTimeFormatter, LocalDateTime, LocalTime} from "@js-joda/core";
 
 const THIRTY_MINUTES = 30;
 const HALF_HOUR_WIDTH = 100;
 
-export function drawTimeline(container, day, userStartOfDay, userEndOfDay, flowData) {
+export function drawTimeline(container, day, flowData) {
     const timelineContainer = <div id={'timeline-container-' + day}/>;
     const timelineHeader = <div class='timeline-header' />;
     const timelineEventsContainer = <div />;
     const timelineEvents = <ul class='timeline-events'/>;
     const timelineHours = <ul class='timelines-years'/>;
-    const startTime = LocalTime.parse(userStartOfDay);
-    const endTime = LocalTime.parse(userEndOfDay);
+    const startTime = LocalTime.parse(config.userStartOfDay);
+    const endTime = LocalTime.parse(config.userEndOfDay);
 
     function flowLeftMargin(flow) {
         if(flowData[0] !== flow) {

--- a/ui/src/css-timeline.js
+++ b/ui/src/css-timeline.js
@@ -1,0 +1,45 @@
+import { dom } from './dom.js';
+import {formatISOTime} from "./date.js";
+import { colorOf } from './color.js';
+
+const THIRTY_MINUTES = 30;
+const MILLISECONDS = 1000;
+const SECONDS = 60;
+const HALF_HOUR_WIDTH = 100;
+
+function timelineFlow(flow) {
+    let flowStartDate = new Date(flow.flowStart);
+    let flowEndDate = new Date(flow.flowEnd);
+    const flowWidth = Math.abs((((flowEndDate.getTime() - flowStartDate.getTime()) / MILLISECONDS / SECONDS) / THIRTY_MINUTES) * HALF_HOUR_WIDTH);
+    return <li style={'width:'+flowWidth+'px'}>
+        <div><h2>{formatISOTime(flowStartDate)}-{formatISOTime(flowEndDate)}</h2><h3>{flow.flowType}</h3></div>
+        <div style={'background: '+colorOf(flow.flowType)+'; position: absolute;left: 0;bottom: -36px;height: 8px;border-radius: 8px;width: 100%;'}></div></li>;
+
+}
+function timelineHour(start) {
+    return <li>{formatISOTime(new Date(start))}</li>;
+
+}
+
+export function drawTimeline(container, flowData) {
+    const timelineContainer = <ul class="timeline-events" />;
+    const timelineHours = <ul class="timelines-years"/>
+
+    function drawTimelineHours() {
+        const firstFlow = flowData[0];
+        const lastFlow = flowData.slice(-1)[0];
+        const nbHalfHours = (new Date(lastFlow.flowEnd).getHours() - new Date(firstFlow.flowStart).getHours()) * 2
+        const firsFlowStartDate = new Date(firstFlow.flowStart);
+        for (let i = 0; i < nbHalfHours; i++) {
+            const hour = new Date(firsFlowStartDate.getFullYear(), firsFlowStartDate.getMonth(), firsFlowStartDate.getDate(), firsFlowStartDate.getHours(), firsFlowStartDate.getMinutes() + i * THIRTY_MINUTES);
+            timelineHours.appendChild(timelineHour(hour));
+        }
+    }
+
+    drawTimelineHours();
+    flowData.forEach(flow => {
+        timelineContainer.appendChild(timelineFlow(flow));
+        container.appendChild(timelineContainer);
+    })
+    container.appendChild(timelineHours);
+}

--- a/ui/src/css-timeline.js
+++ b/ui/src/css-timeline.js
@@ -6,14 +6,16 @@ import {ChronoUnit, DateTimeFormatter, LocalDateTime, LocalTime} from "@js-joda/
 const THIRTY_MINUTES = 30;
 const HALF_HOUR_WIDTH = 100;
 
-export function drawTimeline(container, day, flowData) {
+export function drawTimeline(container, day, flowData, selectedRow = (_ => day)) {
+    const startTime = LocalTime.parse(config.userProfile.userStartOfDay);
+    const endTime = LocalTime.parse(config.userProfile.userEndOfDay);
+    const timelineGap = Object.keys(config.userProfile.userFlowTypes).length * 4;
+
     const timelineContainer = <div id={'timeline-container-' + day}/>;
     const timelineHeader = <div class='timeline-header' />;
     const timelineEventsContainer = <div />;
     const timelineEvents = <ul class='timeline-events'/>;
-    const timelineHours = <ul class='timelines-years'/>;
-    const startTime = LocalTime.parse(config.userStartOfDay);
-    const endTime = LocalTime.parse(config.userEndOfDay);
+    const timelineHours = <ul class='timelines-time'/>;
 
     function flowLeftMargin(flow) {
         if(flowData[0] !== flow) {
@@ -27,9 +29,9 @@ export function drawTimeline(container, day, flowData) {
         let flowStartDate = LocalDateTime.parse(flow.flowStart);
         let flowEndDate = LocalDateTime.parse(flow.flowEnd);
         const flowWidth = Math.abs((flowStartDate.until(flowEndDate, ChronoUnit.MINUTES)/ THIRTY_MINUTES) * HALF_HOUR_WIDTH);
-        return <li style={'width:'+flowWidth+'px; margin-left:'+flowLeftMargin(flow)+'px'}>
-            <div><h2>{flowStartDate.format(DateTimeFormatter.ofPattern("HH:mm"))}</h2><h2>{flowEndDate.format(DateTimeFormatter.ofPattern("HH:mm"))}</h2><h3 style="text-overflow: ellipsis;white-space: nowrap;overflow: hidden">{flow.flowType}</h3></div>
-            <div style={'background: '+colorOf(flow.flowType)+'; position: absolute;left: 0;bottom: -16px;height: 8px;border-radius: 8px;width: 100%;'}></div></li>;
+        return <li style={'width:'+flowWidth+'px; margin-left:'+flowLeftMargin(flow)+'px; padding-bottom: '+timelineGap+'px;'}>
+            <div><h2>{flowStartDate.format(DateTimeFormatter.ofPattern("HH:mm"))}</h2><h2>{flowEndDate.format(DateTimeFormatter.ofPattern("HH:mm"))}</h2><h3>{flow.flowType}</h3></div>
+            <div class='timeline-event' style={'background: '+colorOf(flow.flowType)+'; bottom: '+(-(16 + timelineGap))+'px;'}></div></li>;
 
     }
 

--- a/ui/src/css-timeline.js
+++ b/ui/src/css-timeline.js
@@ -19,11 +19,20 @@ export function drawTimeline(container, day, flowData, rowLabel = (_ => day)) {
 
     function flowLeftMargin(flow) {
         const flowTypeRow = flowMap.get(flow.flowType);
+
+        function isFirstFlow() {
+            return flowTypeRow.indexOf(flow) === 0;
+        }
+
+        function isAfterFirstFlow() {
+            return flowTypeRow.indexOf(flow) > 0;
+        }
+
         if (flowTypeRow !== undefined) {
-            if (flowTypeRow.indexOf(flow) === 0) {
+            if (isFirstFlow()) {
                 return (startTime.until(LocalDateTime.parse(flow.flowStart), ChronoUnit.MINUTES) / THIRTY_MINUTES) * HALF_HOUR_WIDTH;
             }
-            if (flowTypeRow.indexOf(flow) !== -1 && flowTypeRow.indexOf(flow) !== 0) {
+            if (isAfterFirstFlow()) {
                 const previousFlowEnd = LocalDateTime.parse(flowTypeRow[flowTypeRow.indexOf(flow) - 1].flowEnd);
                 return (previousFlowEnd.until(LocalDateTime.parse(flow.flowStart), ChronoUnit.MINUTES) / THIRTY_MINUTES) * HALF_HOUR_WIDTH;
             }
@@ -64,7 +73,7 @@ export function drawTimeline(container, day, flowData, rowLabel = (_ => day)) {
         let flowEndDate = LocalDateTime.parse(flow.flowEnd);
         const flowWidth = Math.abs((flowStartDate.until(flowEndDate, ChronoUnit.MINUTES) / THIRTY_MINUTES) * HALF_HOUR_WIDTH);
         const timelineFlow = <li
-            style={'width:' + flowWidth + 'px; margin-left:' + flowLeftMargin(flow) + 'px; padding-bottom: 8px;'}>
+            style={'width:' + flowWidth + 'px; margin-left:' + flowLeftMargin(flow) + 'px;'}>
             <div>
                 <h2>{flowStartDate.format(DateTimeFormatter.ofPattern("HH:mm"))}</h2>
                 <h2>{flowEndDate.format(DateTimeFormatter.ofPattern("HH:mm"))}</h2>
@@ -100,9 +109,7 @@ export function drawTimeline(container, day, flowData, rowLabel = (_ => day)) {
     toMap().forEach((flows, rowLabel) => {
         const timelineHeader = <div class='timeline-header'/>;
         timelineHeader.style.gridRow = index;
-        timelineHeader.appendChild(<div>
-            <h3>{rowLabel}</h3>
-        </div>);
+        timelineHeader.appendChild(<div><h3>{rowLabel}</h3></div>);
         const timelineEvents = <div class='timeline-events'/>;
         timelineEvents.style.gridRow = index;
         const timelineEvent = <ul/>;

--- a/ui/src/css-timeline.js
+++ b/ui/src/css-timeline.js
@@ -1,29 +1,31 @@
-import { dom } from './dom.js';
+import {dom} from './dom.js';
 import {formatISOTime} from "./date.js";
-import { colorOf } from './color.js';
+import {colorOf} from './color.js';
 
 const THIRTY_MINUTES = 30;
 const MILLISECONDS = 1000;
 const SECONDS = 60;
 const HALF_HOUR_WIDTH = 100;
 
-function timelineFlow(flow) {
+function drawTimelineFlow(flow) {
     let flowStartDate = new Date(flow.flowStart);
     let flowEndDate = new Date(flow.flowEnd);
     const flowWidth = Math.abs((((flowEndDate.getTime() - flowStartDate.getTime()) / MILLISECONDS / SECONDS) / THIRTY_MINUTES) * HALF_HOUR_WIDTH);
     return <li style={'width:'+flowWidth+'px'}>
-        <div><h2>{formatISOTime(flowStartDate)}-{formatISOTime(flowEndDate)}</h2><h3>{flow.flowType}</h3></div>
-        <div style={'background: '+colorOf(flow.flowType)+'; position: absolute;left: 0;bottom: -36px;height: 8px;border-radius: 8px;width: 100%;'}></div></li>;
+        <div><h2>{formatISOTime(flowStartDate)}</h2><h2>{formatISOTime(flowEndDate)}</h2><h3 style="text-overflow: ellipsis;white-space: nowrap;overflow: hidden">{flow.flowType}</h3></div>
+        <div style={'background: '+colorOf(flow.flowType)+'; position: absolute;left: 0;bottom: -16px;height: 8px;border-radius: 8px;width: 100%;'}></div></li>;
 
 }
-function timelineHour(start) {
+
+function drawTimelineHour(start) {
     return <li>{formatISOTime(new Date(start))}</li>;
 
 }
 
-export function drawTimeline(container, flowData) {
-    const timelineContainer = <ul class="timeline-events" />;
-    const timelineHours = <ul class="timelines-years"/>
+export function drawTimeline(container, day, flowData) {
+    const timelineContainer = <div id={'timeline-container-' + day}/>;
+    const timelineEvents = <ul class='timeline-events'/>;
+    const timelineHours = <ul class='timelines-years'/>;
 
     function drawTimelineHours() {
         const firstFlow = flowData[0];
@@ -32,14 +34,15 @@ export function drawTimeline(container, flowData) {
         const firsFlowStartDate = new Date(firstFlow.flowStart);
         for (let i = 0; i < nbHalfHours; i++) {
             const hour = new Date(firsFlowStartDate.getFullYear(), firsFlowStartDate.getMonth(), firsFlowStartDate.getDate(), firsFlowStartDate.getHours(), firsFlowStartDate.getMinutes() + i * THIRTY_MINUTES);
-            timelineHours.appendChild(timelineHour(hour));
+            timelineHours.appendChild(drawTimelineHour(hour));
         }
     }
 
     drawTimelineHours();
     flowData.forEach(flow => {
-        timelineContainer.appendChild(timelineFlow(flow));
-        container.appendChild(timelineContainer);
+        timelineEvents.appendChild(drawTimelineFlow(flow));
+        timelineContainer.appendChild(timelineEvents);
     })
-    container.appendChild(timelineHours);
+    timelineContainer.appendChild(timelineHours);
+    container.appendChild(timelineContainer);
 }

--- a/ui/src/css-timeline.js
+++ b/ui/src/css-timeline.js
@@ -1,6 +1,7 @@
 import {dom} from './dom.js';
 import {formatISOTime} from "./date.js";
 import {colorOf} from './color.js';
+import {DateTimeFormatter, LocalTime} from "@js-joda/core";
 
 const THIRTY_MINUTES = 30;
 const MILLISECONDS = 1000;
@@ -17,32 +18,35 @@ function drawTimelineFlow(flow) {
 
 }
 
-function drawTimelineHour(start) {
-    return <li>{formatISOTime(new Date(start))}</li>;
+function drawTimelineHour(time) {
+    return <li>{time.format(DateTimeFormatter.ofPattern('HH:mm'))}</li>;
 
 }
 
-export function drawTimeline(container, day, flowData) {
+export function drawTimeline(container, day, userStartOfDay, userEndOfDay, flowData) {
     const timelineContainer = <div id={'timeline-container-' + day}/>;
+    const timelineHeader = <div class='timeline-header' />;
+    const timelineEventsContainer = <div />;
     const timelineEvents = <ul class='timeline-events'/>;
     const timelineHours = <ul class='timelines-years'/>;
 
     function drawTimelineHours() {
-        const firstFlow = flowData[0];
-        const lastFlow = flowData.slice(-1)[0];
-        const nbHalfHours = (new Date(lastFlow.flowEnd).getHours() - new Date(firstFlow.flowStart).getHours()) * 2
-        const firsFlowStartDate = new Date(firstFlow.flowStart);
+        const startTime = LocalTime.parse(userStartOfDay);
+        const nbHalfHours = (LocalTime.parse(userEndOfDay).hour() - startTime.hour()) * 2
         for (let i = 0; i < nbHalfHours; i++) {
-            const hour = new Date(firsFlowStartDate.getFullYear(), firsFlowStartDate.getMonth(), firsFlowStartDate.getDate(), firsFlowStartDate.getHours(), firsFlowStartDate.getMinutes() + i * THIRTY_MINUTES);
-            timelineHours.appendChild(drawTimelineHour(hour));
+            const time =  startTime.plusMinutes(i * THIRTY_MINUTES);
+            timelineHours.appendChild(drawTimelineHour(time));
         }
     }
 
+    timelineHeader.appendChild(<h3>{day}</h3>);
     drawTimelineHours();
     flowData.forEach(flow => {
         timelineEvents.appendChild(drawTimelineFlow(flow));
-        timelineContainer.appendChild(timelineEvents);
+        timelineEventsContainer.appendChild(timelineEvents);
     })
-    timelineContainer.appendChild(timelineHours);
+    timelineEventsContainer.appendChild(timelineHours);
+    timelineContainer.appendChild(timelineHeader);
+    timelineContainer.appendChild(timelineEventsContainer);
     container.appendChild(timelineContainer);
 }

--- a/ui/src/css-timeline.js
+++ b/ui/src/css-timeline.js
@@ -73,18 +73,20 @@ export function drawTimeline(container, day, flowData, rowLabel = (_ => day)) {
     }
 
     function drawTimelineTimeFlows(flow) {
-        let flowStartDate = LocalDateTime.parse(flow.flowStart);
-        let flowEndDate = LocalDateTime.parse(flow.flowEnd);
-        const flowWidth = Math.abs((flowStartDate.until(flowEndDate, ChronoUnit.MINUTES) / THIRTY_MINUTES) * HALF_HOUR_WIDTH);
-        const timelineFlow = <li
-            style={'width:' + flowWidth + 'px; margin-left:' + flowLeftMargin(flow) + 'px;'}>
-            <div>
-                <h2>{flowStartDate.format(DateTimeFormatter.ofPattern("HH:mm"))}</h2>
-                <h2>{flowEndDate.format(DateTimeFormatter.ofPattern("HH:mm"))}</h2>
-                <h3>{flow.flowType}</h3>
-            </div>
-        </li>;
-        timelineFlows.appendChild(timelineFlow);
+        if(!timelineFlows.childNodes || timelineFlows.childNodes.length !== flowData.length) {
+            let flowStartDate = LocalDateTime.parse(flow.flowStart);
+            let flowEndDate = LocalDateTime.parse(flow.flowEnd);
+            const flowWidth = Math.abs((flowStartDate.until(flowEndDate, ChronoUnit.MINUTES) / THIRTY_MINUTES) * HALF_HOUR_WIDTH);
+            const timelineFlow = <li
+                style={'width:' + flowWidth + 'px; margin-left:' + flowLeftMargin(flow) + 'px;'}>
+                <div>
+                    <h2>{flowStartDate.format(DateTimeFormatter.ofPattern("HH:mm"))}</h2>
+                    <h2>{flowEndDate.format(DateTimeFormatter.ofPattern("HH:mm"))}</h2>
+                    <h3>{flow.flowType}</h3>
+                </div>
+            </li>;
+            timelineFlows.appendChild(timelineFlow);
+        }
     }
 
     function toMap() {
@@ -119,7 +121,7 @@ export function drawTimeline(container, day, flowData, rowLabel = (_ => day)) {
     }
 
     clearContainer();
-    if (!container.firstChild) {
+    if (!timelineFlowsContainer.firstChild) {
         timelineFlowsContainer.appendChild(timelineFlows);
         timelineContainer.appendChild(timelineFlowsContainer);
     }

--- a/ui/src/css-timeline.js
+++ b/ui/src/css-timeline.js
@@ -1,27 +1,9 @@
 import {dom} from './dom.js';
-import {formatISOTime} from "./date.js";
 import {colorOf} from './color.js';
-import {DateTimeFormatter, LocalTime} from "@js-joda/core";
+import {ChronoUnit, DateTimeFormatter, LocalDateTime, LocalTime} from "@js-joda/core";
 
 const THIRTY_MINUTES = 30;
-const MILLISECONDS = 1000;
-const SECONDS = 60;
 const HALF_HOUR_WIDTH = 100;
-
-function drawTimelineFlow(flow) {
-    let flowStartDate = new Date(flow.flowStart);
-    let flowEndDate = new Date(flow.flowEnd);
-    const flowWidth = Math.abs((((flowEndDate.getTime() - flowStartDate.getTime()) / MILLISECONDS / SECONDS) / THIRTY_MINUTES) * HALF_HOUR_WIDTH);
-    return <li style={'width:'+flowWidth+'px'}>
-        <div><h2>{formatISOTime(flowStartDate)}</h2><h2>{formatISOTime(flowEndDate)}</h2><h3 style="text-overflow: ellipsis;white-space: nowrap;overflow: hidden">{flow.flowType}</h3></div>
-        <div style={'background: '+colorOf(flow.flowType)+'; position: absolute;left: 0;bottom: -16px;height: 8px;border-radius: 8px;width: 100%;'}></div></li>;
-
-}
-
-function drawTimelineHour(time) {
-    return <li>{time.format(DateTimeFormatter.ofPattern('HH:mm'))}</li>;
-
-}
 
 export function drawTimeline(container, day, userStartOfDay, userEndOfDay, flowData) {
     const timelineContainer = <div id={'timeline-container-' + day}/>;
@@ -29,10 +11,34 @@ export function drawTimeline(container, day, userStartOfDay, userEndOfDay, flowD
     const timelineEventsContainer = <div />;
     const timelineEvents = <ul class='timeline-events'/>;
     const timelineHours = <ul class='timelines-years'/>;
+    const startTime = LocalTime.parse(userStartOfDay);
+    const endTime = LocalTime.parse(userEndOfDay);
+
+    function flowLeftMargin(flow) {
+        if(flowData[0] !== flow) {
+            return 0;
+        }
+        const firstFlowStartTime = LocalDateTime.parse(flowData[0].flowStart);
+        return firstFlowStartTime.toLocalTime().compareTo(startTime) !== 0 ? (startTime.until(firstFlowStartTime.toLocalTime(), ChronoUnit.MINUTES) / THIRTY_MINUTES) * HALF_HOUR_WIDTH : 0;
+    }
+
+    function drawTimelineFlow(flow) {
+        let flowStartDate = LocalDateTime.parse(flow.flowStart);
+        let flowEndDate = LocalDateTime.parse(flow.flowEnd);
+        const flowWidth = Math.abs((flowStartDate.until(flowEndDate, ChronoUnit.MINUTES)/ THIRTY_MINUTES) * HALF_HOUR_WIDTH);
+        return <li style={'width:'+flowWidth+'px; margin-left:'+flowLeftMargin(flow)+'px'}>
+            <div><h2>{flowStartDate.format(DateTimeFormatter.ofPattern("HH:mm"))}</h2><h2>{flowEndDate.format(DateTimeFormatter.ofPattern("HH:mm"))}</h2><h3 style="text-overflow: ellipsis;white-space: nowrap;overflow: hidden">{flow.flowType}</h3></div>
+            <div style={'background: '+colorOf(flow.flowType)+'; position: absolute;left: 0;bottom: -16px;height: 8px;border-radius: 8px;width: 100%;'}></div></li>;
+
+    }
+
+    function drawTimelineHour(time) {
+        return <li>{time.format(DateTimeFormatter.ofPattern('HH:mm'))}</li>;
+
+    }
 
     function drawTimelineHours() {
-        const startTime = LocalTime.parse(userStartOfDay);
-        const nbHalfHours = (LocalTime.parse(userEndOfDay).hour() - startTime.hour()) * 2
+        const nbHalfHours = (endTime.hour() - startTime.hour()) * 2
         for (let i = 0; i < nbHalfHours; i++) {
             const time =  startTime.plusMinutes(i * THIRTY_MINUTES);
             timelineHours.appendChild(drawTimelineHour(time));

--- a/ui/src/css-timeline.test.js
+++ b/ui/src/css-timeline.test.js
@@ -48,7 +48,7 @@ const flowData = [
 describe('CSS Timeline', () => {
     test('expect timiline to be drawn', () => {
         let container = document.createElement("div");
-        drawTimeline(container, flowData);
+        drawTimeline(container, '2020-12-17', flowData);
         expect(container).toMatchSnapshot();
     });
 });

--- a/ui/src/css-timeline.test.js
+++ b/ui/src/css-timeline.test.js
@@ -46,9 +46,21 @@ const flowData = [
 ];
 
 describe('CSS Timeline', () => {
-    test('expect timiline to be drawn', () => {
+    test('expect timeline to be drawn', () => {
         let container = document.createElement("div");
         drawTimeline(container, '2020-12-17', '08:30:00', '17:00:00', flowData);
+        expect(container).toMatchSnapshot();
+    });
+
+    test('expect timeline to be drawn with negative left margin when flow start before user start of day', () => {
+        let container = document.createElement("div");
+        drawTimeline(container, '2020-12-17', '09:00:00', '17:00:00', flowData);
+        expect(container).toMatchSnapshot();
+    });
+
+    test('expect timeline to be drawn with positive left margin when flow start after user start of day', () => {
+        let container = document.createElement("div");
+        drawTimeline(container, '2020-12-17', '08:00:00', '17:00:00', flowData);
         expect(container).toMatchSnapshot();
     });
 });

--- a/ui/src/css-timeline.test.js
+++ b/ui/src/css-timeline.test.js
@@ -86,7 +86,7 @@ describe('CSS Timeline', () => {
         expect(container).toMatchSnapshot();
     });
 
-    test('expect timeline to be expand at selected date', () => {
+    xtest('expect timeline to be expand at selected date', () => {
         config.userProfile.userStartOfDay = '08:00:00';
         config.userProfile.userEndOfDay = '17:00:00';
         let container = document.createElement("div");

--- a/ui/src/css-timeline.test.js
+++ b/ui/src/css-timeline.test.js
@@ -1,0 +1,54 @@
+import {dom} from './dom.js';
+import {formatISOTime} from "./date.js";
+
+import {describe, expect, test} from '@jest/globals';
+import {drawTimeline} from "./css-timeline";
+
+const flowData = [
+    {
+        "flowStart": "2020-12-17T08:30:00",
+        "flowType": "Flowing",
+        "flowEnd": "2020-12-17T09:00:00"
+    }, {
+        "flowStart": "2020-12-17T09:00:00",
+        "flowType": "Daily",
+        "flowEnd": "2020-12-17T09:30:00"
+    }, {
+        "flowStart": "2020-12-17T09:30:00",
+        "flowType": "Meeting",
+        "flowEnd": "2020-12-17T10:15:00"
+    }, {
+        "flowStart": "2020-12-17T10:15:00",
+        "flowType": "Meeting",
+        "flowEnd": "2020-12-17T12:00:00"
+    }, {
+        "flowStart": "2020-12-17T12:00:00",
+        "flowType": "Other",
+        "flowEnd": "2020-12-17T13:40:00"
+    }, {
+        "flowStart": "2020-12-17T13:40:00",
+        "flowType": "Meeting",
+        "flowEnd": "2020-12-17T14:00:00"
+    }, {
+        "flowStart": "2020-12-17T14:00:00",
+        "flowType": "Meeting",
+        "flowEnd": "2020-12-17T15:00:00"
+    }, {
+        "flowStart": "2020-12-17T15:00:00",
+        "flowType": "Rework",
+        "flowEnd": "2020-12-17T17:00:00"
+    },
+    {
+        "flowStart": "2020-12-17T17:00:00",
+        "flowType": "Meeting",
+        "flowEnd": "2020-12-17T17:00:00"
+    }
+];
+
+describe('CSS Timeline', () => {
+    test('expect timiline to be drawn', () => {
+        let container = document.createElement("div");
+        drawTimeline(container, flowData);
+        expect(container).toMatchSnapshot();
+    });
+});

--- a/ui/src/css-timeline.test.js
+++ b/ui/src/css-timeline.test.js
@@ -67,7 +67,7 @@ describe('CSS Timeline', () => {
         config.userStartOfDay = '08:00:00';
         config.userEndOfDay = '17:00:00';
         let container = document.createElement("div");
-        drawTimeline(container, '2020-12-17', flowData);
+        drawTimeline(container, '2020-12-17', '08:30:00', '17:00:00', flowData);
         expect(container).toMatchSnapshot();
     });
 });

--- a/ui/src/css-timeline.test.js
+++ b/ui/src/css-timeline.test.js
@@ -82,15 +82,15 @@ describe('CSS Timeline', () => {
         config.userProfile.userStartOfDay = '08:00:00';
         config.userProfile.userEndOfDay = '17:00:00';
         let container = document.createElement("div");
-        drawTimeline(container, '2020-12-17', '08:30:00', '17:00:00', flowData);
+        drawTimeline(container, '2020-12-17', flowData);
         expect(container).toMatchSnapshot();
     });
 
-    xtest('expect timeline to be expand at selected date', () => {
+    test('expect timeline to be expand at selected date', () => {
         config.userProfile.userStartOfDay = '08:00:00';
         config.userProfile.userEndOfDay = '17:00:00';
         let container = document.createElement("div");
-        drawTimeline(container, '2020-12-17', flowData, () => '2020-12-17');
+        drawTimeline(container, '2020-12-17', flowData, f => f.flowType);
         expect(container).toMatchSnapshot();
     });
 });

--- a/ui/src/css-timeline.test.js
+++ b/ui/src/css-timeline.test.js
@@ -1,5 +1,6 @@
 import {dom} from './dom.js';
 import {formatISOTime} from "./date.js";
+import { config } from "./config";
 
 import {describe, expect, test} from '@jest/globals';
 import {drawTimeline} from "./css-timeline";
@@ -47,20 +48,26 @@ const flowData = [
 
 describe('CSS Timeline', () => {
     test('expect timeline to be drawn', () => {
+        config.userStartOfDay = '08:30:00';
+        config.userEndOfDay = '17:00:00';
         let container = document.createElement("div");
-        drawTimeline(container, '2020-12-17', '08:30:00', '17:00:00', flowData);
+        drawTimeline(container, '2020-12-17', flowData);
         expect(container).toMatchSnapshot();
     });
 
     test('expect timeline to be drawn with negative left margin when flow start before user start of day', () => {
+        config.userStartOfDay = '09:00:00';
+        config.userEndOfDay = '17:00:00';
         let container = document.createElement("div");
-        drawTimeline(container, '2020-12-17', '09:00:00', '17:00:00', flowData);
+        drawTimeline(container, '2020-12-17', flowData);
         expect(container).toMatchSnapshot();
     });
 
     test('expect timeline to be drawn with positive left margin when flow start after user start of day', () => {
+        config.userStartOfDay = '08:00:00';
+        config.userEndOfDay = '17:00:00';
         let container = document.createElement("div");
-        drawTimeline(container, '2020-12-17', '08:00:00', '17:00:00', flowData);
+        drawTimeline(container, '2020-12-17', flowData);
         expect(container).toMatchSnapshot();
     });
 });

--- a/ui/src/css-timeline.test.js
+++ b/ui/src/css-timeline.test.js
@@ -48,7 +48,7 @@ const flowData = [
 describe('CSS Timeline', () => {
     test('expect timiline to be drawn', () => {
         let container = document.createElement("div");
-        drawTimeline(container, '2020-12-17', flowData);
+        drawTimeline(container, '2020-12-17', '08:30:00', '17:00:00', flowData);
         expect(container).toMatchSnapshot();
     });
 });

--- a/ui/src/css-timeline.test.js
+++ b/ui/src/css-timeline.test.js
@@ -4,6 +4,7 @@ import {config} from "./config";
 
 import {describe, expect, test} from '@jest/globals';
 import {drawTimeline} from "./css-timeline";
+import {drawCssNotes} from "./css-notes";
 
 const flowData = [
     {
@@ -46,6 +47,17 @@ const flowData = [
     }
 ];
 
+const notes = [{
+    "noteStart": "2020-11-16T09:30:00",
+    "noteContent": "# Note\r## Première note"
+}, {
+    "noteStart": "2020-11-16T10:55:00",
+    "noteContent": "# Note\r## Seconde note"
+}, {
+    "noteStart": "2020-11-16T12:20:00",
+    "noteContent": "# Note\r## Troisième note"
+}];
+
 describe('CSS Timeline', () => {
 
     beforeEach(() => {
@@ -66,7 +78,9 @@ describe('CSS Timeline', () => {
         config.userProfile.userStartOfDay = '08:30:00';
         config.userProfile.userEndOfDay = '17:00:00';
         let container = document.createElement("div");
+
         drawTimeline(container, '2020-12-17', flowData);
+
         expect(container).toMatchSnapshot();
     });
 
@@ -74,7 +88,9 @@ describe('CSS Timeline', () => {
         config.userProfile.userStartOfDay = '09:00:00';
         config.userProfile.userEndOfDay = '17:00:00';
         let container = document.createElement("div");
+
         drawTimeline(container, '2020-12-17', flowData);
+
         expect(container).toMatchSnapshot();
     });
 
@@ -82,7 +98,9 @@ describe('CSS Timeline', () => {
         config.userProfile.userStartOfDay = '08:00:00';
         config.userProfile.userEndOfDay = '17:00:00';
         let container = document.createElement("div");
+
         drawTimeline(container, '2020-12-17', flowData);
+
         expect(container).toMatchSnapshot();
     });
 
@@ -90,7 +108,34 @@ describe('CSS Timeline', () => {
         config.userProfile.userStartOfDay = '08:00:00';
         config.userProfile.userEndOfDay = '17:00:00';
         let container = document.createElement("div");
+
         drawTimeline(container, '2020-12-17', flowData, f => f.flowType);
+
         expect(container).toMatchSnapshot();
+    });
+
+    test('expect timeline not to clear notes', () => {
+        config.userProfile.userStartOfDay = '08:00:00';
+        config.userProfile.userEndOfDay = '17:00:00';
+        let container = document.createElement("div");
+
+        drawTimeline(container, '2020-12-17', flowData);
+        drawCssNotes(container, '2020-12-17', notes);
+        drawTimeline(container, '2020-12-17', flowData, f => f.flowType);
+
+        expect(container).toMatchSnapshot();
+
+    });
+
+    test('expect timeline to have row label with flowtype after being drawn without', () => {
+        config.userProfile.userStartOfDay = '08:00:00';
+        config.userProfile.userEndOfDay = '17:00:00';
+        let container = document.createElement("div");
+
+        drawTimeline(container, '2020-12-17', flowData);
+        drawTimeline(container, '2020-12-17', flowData, f => f.flowType);
+
+        expect(container).toMatchSnapshot();
+
     });
 });

--- a/ui/src/css-timeline.test.js
+++ b/ui/src/css-timeline.test.js
@@ -1,5 +1,4 @@
 import {dom} from './dom.js';
-import {formatISOTime} from "./date.js";
 import {config} from "./config";
 
 import {describe, expect, test} from '@jest/globals';
@@ -60,6 +59,9 @@ const notes = [{
 
 describe('CSS Timeline', () => {
 
+    let mainContainer;
+    let container;
+
     beforeEach(() => {
         config.userProfile = {
             userFlowTypes: {
@@ -72,12 +74,15 @@ describe('CSS Timeline', () => {
                 "Experimenting": "#0022dd"
             }
         };
+        container = document.createElement("div");
+        mainContainer = <div id="main" />;
+        mainContainer.appendChild(container);
+        document.body.appendChild(mainContainer);
     });
 
     test('expect timeline to be drawn', () => {
         config.userProfile.userStartOfDay = '08:30:00';
         config.userProfile.userEndOfDay = '17:00:00';
-        let container = document.createElement("div");
 
         drawTimeline(container, '2020-12-17', flowData);
 
@@ -87,7 +92,6 @@ describe('CSS Timeline', () => {
     test('expect timeline to be drawn with negative left margin when flow start before user start of day', () => {
         config.userProfile.userStartOfDay = '09:00:00';
         config.userProfile.userEndOfDay = '17:00:00';
-        let container = document.createElement("div");
 
         drawTimeline(container, '2020-12-17', flowData);
 
@@ -97,7 +101,6 @@ describe('CSS Timeline', () => {
     test('expect timeline to be drawn with positive left margin when flow start after user start of day', () => {
         config.userProfile.userStartOfDay = '08:00:00';
         config.userProfile.userEndOfDay = '17:00:00';
-        let container = document.createElement("div");
 
         drawTimeline(container, '2020-12-17', flowData);
 
@@ -107,7 +110,6 @@ describe('CSS Timeline', () => {
     test('expect timeline to be expand at selected date', () => {
         config.userProfile.userStartOfDay = '08:00:00';
         config.userProfile.userEndOfDay = '17:00:00';
-        let container = document.createElement("div");
 
         drawTimeline(container, '2020-12-17', flowData, f => f.flowType);
 
@@ -117,7 +119,6 @@ describe('CSS Timeline', () => {
     test('expect timeline not to clear notes', () => {
         config.userProfile.userStartOfDay = '08:00:00';
         config.userProfile.userEndOfDay = '17:00:00';
-        let container = document.createElement("div");
 
         drawTimeline(container, '2020-12-17', flowData);
         drawCssNotes(container, '2020-12-17', notes);
@@ -130,7 +131,6 @@ describe('CSS Timeline', () => {
     test('expect timeline to have row label with flowtype after being drawn without', () => {
         config.userProfile.userStartOfDay = '08:00:00';
         config.userProfile.userEndOfDay = '17:00:00';
-        let container = document.createElement("div");
 
         drawTimeline(container, '2020-12-17', flowData);
         drawTimeline(container, '2020-12-17', flowData, f => f.flowType);

--- a/ui/src/css-timeline.test.js
+++ b/ui/src/css-timeline.test.js
@@ -1,6 +1,6 @@
 import {dom} from './dom.js';
 import {formatISOTime} from "./date.js";
-import { config } from "./config";
+import {config} from "./config";
 
 import {describe, expect, test} from '@jest/globals';
 import {drawTimeline} from "./css-timeline";
@@ -47,27 +47,50 @@ const flowData = [
 ];
 
 describe('CSS Timeline', () => {
+
+    beforeEach(() => {
+        config.userProfile = {
+            userFlowTypes: {
+                "Other": "#33ffd4",
+                "Learning": "#ff8822",
+                "Flowing": "#00dd22",
+                "Troubleshooting": "#ee1111",
+                "Rework": "#4500dd",
+                "Meeting": "#fff203",
+                "Experimenting": "#0022dd"
+            }
+        };
+    });
+
     test('expect timeline to be drawn', () => {
-        config.userStartOfDay = '08:30:00';
-        config.userEndOfDay = '17:00:00';
+        config.userProfile.userStartOfDay = '08:30:00';
+        config.userProfile.userEndOfDay = '17:00:00';
         let container = document.createElement("div");
         drawTimeline(container, '2020-12-17', flowData);
         expect(container).toMatchSnapshot();
     });
 
     test('expect timeline to be drawn with negative left margin when flow start before user start of day', () => {
-        config.userStartOfDay = '09:00:00';
-        config.userEndOfDay = '17:00:00';
+        config.userProfile.userStartOfDay = '09:00:00';
+        config.userProfile.userEndOfDay = '17:00:00';
         let container = document.createElement("div");
         drawTimeline(container, '2020-12-17', flowData);
         expect(container).toMatchSnapshot();
     });
 
     test('expect timeline to be drawn with positive left margin when flow start after user start of day', () => {
-        config.userStartOfDay = '08:00:00';
-        config.userEndOfDay = '17:00:00';
+        config.userProfile.userStartOfDay = '08:00:00';
+        config.userProfile.userEndOfDay = '17:00:00';
         let container = document.createElement("div");
         drawTimeline(container, '2020-12-17', '08:30:00', '17:00:00', flowData);
+        expect(container).toMatchSnapshot();
+    });
+
+    test('expect timeline to be expand at selected date', () => {
+        config.userProfile.userStartOfDay = '08:00:00';
+        config.userProfile.userEndOfDay = '17:00:00';
+        let container = document.createElement("div");
+        drawTimeline(container, '2020-12-17', flowData, () => '2020-12-17');
         expect(container).toMatchSnapshot();
     });
 });

--- a/ui/src/notes.js
+++ b/ui/src/notes.js
@@ -15,7 +15,7 @@ function markdownNote(note) {
 
 function formatNote(note) {
   return "<div class='note'>" +
-    markdownNote(note) +
+    new showdown.Converter({ simplifiedAutoLink: true }).makeHtml('#### ' + new Date(note.noteStart).toLocaleTimeString() + '\n\n' + note.noteContent) +
     "</div>";
 }
 

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -104,18 +104,16 @@ div#notes .note-full {
 
 .timelines-years {
     position: absolute;
-    top: 250px;
-    padding: 0 0 0 100px;
+    padding: 60px 0 0 100px;
     margin: 0;
     white-space: nowrap;
-    border-top: 1px solid #282828;
+    border-bottom: 1px solid #282828;
     list-style: none;
-    /* Fix display: inline-block spacing issue */;
     font-size: 0;
 }
 .timelines-years li {
     position: relative;
-    top: -6px;
+    top: 6px;
     display: inline-block;
     width: 100px;
     color: #868686;
@@ -123,19 +121,15 @@ div#notes .note-full {
     line-height: 11px;
     text-indent: -12px;
 }
-/* Display last year */
 .timelines-years li:last-child {
     width: 100px;
 }
 
-/* Timeline - Events */
 .timeline-events {
     position: absolute;
-    top: 170px;
     padding: 0 0 0 100px;
     list-style: none;
     white-space: nowrap;
-    /* Fix display: inline-block spacing issue */;
     font-size: 0;
 }
 .timeline-events h2,
@@ -156,4 +150,9 @@ div#notes .note-full {
 .timeline-events li {
     position: relative;
     display: inline-block;
+}
+
+div [id^='timeline-container-'] {
+    height: 80px;
+    padding-bottom: 16px;
 }

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -63,7 +63,6 @@ div#timelines {
 }
 
 .note {
-    max-width: 20em;
     padding: .5em;
 }
 
@@ -224,6 +223,19 @@ div#notes .note-full {
     display: inline-block;
 }
 
+.timeline-header {
+    grid-column: 1/1;
+    grid-row: auto/auto;
+}
+
+.timeline-header > div h2,
+.timeline-header > div h3,
+.timeline-header > div h4 {
+    margin: 0 0 1px 0;
+    font-weight: normal;
+    font-size: 14px;
+}
+
 .timeline-events ul .timeline-event {
     position: absolute;
     left: 0;
@@ -234,6 +246,11 @@ div#notes .note-full {
 
 .timeline-event {
     opacity: 0.6;
+}
+
+.timeline-note {
+    cursor: pointer;
+    background: #315273;
 }
 
 div [id^='timeline-container-'] {
@@ -269,19 +286,6 @@ div [id^='notes-'] ul li div {
     width: 100%;
 }
 
-.timeline-header {
-    grid-column: 1/1;
-    grid-row: auto/auto;
-}
-
-.timeline-header > div h2,
-.timeline-header > div h3,
-.timeline-header > div h4 {
-    margin: 0 0 1px 0;
-    font-weight: normal;
-    font-size: 14px;
-}
-
 .c-dialog {
     position: fixed;
     z-index: 100;
@@ -303,6 +307,17 @@ div [id^='notes-'] ul li div {
     margin: auto;
     padding: 2.4rem;
     background-color: white;
+    border-radius: 12px;
+}
+
+.c-dialog__box div[type="button"] {
+    cursor: pointer;
+    font-size: 18px;
+    text-align: end;
+    color: #777777;
+    text-shadow:
+            -0.0075em 0.0075em 0 #ddd,
+            0.005em 0.005em 0 #333;
 }
 
 .c-dialog[aria-hidden="true"] {

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -149,6 +149,10 @@ div#notes .note-full {
     font-size: 0;
 }
 
+.timeline-flows ul li {
+    padding-bottom: 8px;
+}
+
 .timeline-flows ul h2,
 .timeline-flows ul h3,
 .timeline-flows ul h4 {

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -12,7 +12,7 @@ pre {
 
 div#navbar {
     position: fixed;
-    top:0;
+    top: 0;
     left: 0;
     width: 100%;
     height: 40px;
@@ -21,10 +21,10 @@ div#navbar {
 }
 
 div#navbar ul {
-  list-style-type: none;
-  height: 40px;
-  margin: 0;
-  padding: 0;
+    list-style-type: none;
+    height: 40px;
+    margin: 0;
+    padding: 0;
 }
 
 div#navbar li {
@@ -46,7 +46,7 @@ div#navbar li a:hover {
 div#main {
     top: 40px;
     position: relative;
-    padding:1em;
+    padding: 1em;
 }
 
 div#timelines {
@@ -55,11 +55,11 @@ div#timelines {
 }
 
 .summary {
-    width:100%;
+    width: 100%;
 }
 
 .summaryChart {
-    width:100%;
+    width: 100%;
 }
 
 .note {
@@ -85,16 +85,16 @@ div#notes .note-full {
 }
 
 .note-full h3 {
-    display:inline-block;
+    display: inline-block;
     width: 6%;
     vertical-align: top;
-    color:lightgray;
-    font-size:80%;
+    color: lightgray;
+    font-size: 80%;
 }
 
 .note-content {
     display: inline-block;
-    width:94%;
+    width: 94%;
     vertical-align: top;
 }
 
@@ -103,17 +103,22 @@ div#notes .note-full {
     padding-bottom: 12px;
 }
 
+.timeline {
+    padding: 0 0 60px 0;
+}
 
-.timelines-years {
+
+.timelines-time {
     position: absolute;
-    padding: 60px 0 0 100px;
+    padding: 120px 0 0 100px;
     margin: 0;
     white-space: nowrap;
     border-bottom: 1px solid #282828;
     list-style: none;
     font-size: 0;
 }
-.timelines-years li {
+
+.timelines-time li {
     position: relative;
     top: 6px;
     display: inline-block;
@@ -123,7 +128,8 @@ div#notes .note-full {
     line-height: 11px;
     text-indent: -12px;
 }
-.timelines-years li:last-child {
+
+.timelines-time li:last-child {
     width: 100px;
 }
 
@@ -134,6 +140,7 @@ div#notes .note-full {
     white-space: nowrap;
     font-size: 0;
 }
+
 .timeline-events h2,
 .timeline-events h3,
 .timeline-events h4 {
@@ -141,17 +148,34 @@ div#notes .note-full {
     font-weight: normal;
     font-size: 11px;
 }
+
 .timeline-events h2 {
     color: #777;
     text-transform: uppercase;
 }
+
+.timeline-events h3 {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden
+}
+
 .timeline-events h4 {
     color: #fff;
     font-style: italic;
 }
+
 .timeline-events li {
     position: relative;
     display: inline-block;
+}
+
+.timeline-events .timeline-event {
+    position: absolute;
+    left: 0;
+    height: 8px;
+    border-radius: 8px;
+    width: 100%;
 }
 
 div [id^='timeline-container-'] {

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -97,3 +97,63 @@ div#notes .note-full {
     width:94%;
     vertical-align: top;
 }
+
+
+
+
+
+.timelines-years {
+    position: absolute;
+    top: 250px;
+    padding: 0 0 0 100px;
+    margin: 0;
+    white-space: nowrap;
+    border-top: 1px solid #282828;
+    list-style: none;
+    /* Fix display: inline-block spacing issue */;
+    font-size: 0;
+}
+.timelines-years li {
+    position: relative;
+    top: -6px;
+    display: inline-block;
+    width: 100px;
+    color: #868686;
+    font-size: 11px;
+    line-height: 11px;
+    text-indent: -12px;
+}
+/* Display last year */
+.timelines-years li:last-child {
+    width: 100px;
+}
+
+/* Timeline - Events */
+.timeline-events {
+    position: absolute;
+    top: 170px;
+    padding: 0 0 0 100px;
+    list-style: none;
+    white-space: nowrap;
+    /* Fix display: inline-block spacing issue */;
+    font-size: 0;
+}
+.timeline-events h2,
+.timeline-events h3,
+.timeline-events h4 {
+    margin: 0 0 1px 0;
+    font-weight: normal;
+    font-size: 11px;
+}
+.timeline-events h2 {
+    color: #777;
+    text-transform: uppercase;
+}
+.timeline-events h4 {
+    color: #fff;
+    font-style: italic;
+}
+.timeline-events li {
+    position: relative;
+    display: inline-block;
+}

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -109,6 +109,7 @@ div#notes .note-full {
 
 .timeline-time {
     grid-column: 1/24;
+    grid-row: auto/auto;
 }
 
 .timeline-time ul {
@@ -138,11 +139,10 @@ div#notes .note-full {
 
 .timeline-flows {
     grid-column: 1/24;
-    grid-row: 1;
+    grid-row: auto/auto;
 }
 
 .timeline-flows ul {
-    /*position: absolute;*/
     padding: 0 0 0 100px;
     list-style: none;
     white-space: nowrap;
@@ -183,6 +183,7 @@ div#notes .note-full {
 }
 
 .timeline-events{
+    grid-row: auto / auto;
     grid-column: 2/24;
 }
 
@@ -238,16 +239,39 @@ div#notes .note-full {
 div [id^='timeline-container-'] {
     padding-bottom: 16px;
     display: grid;
-    /*flex-direction: row;*/
     grid-template-columns: repeat(24, 100px);
+}
+
+div [id^='notes-'] {
+    grid-row: auto / auto;
+    grid-column: 2/24;
+}
+
+div [id^='notes-'] ul {
+    padding: 0 0 4px 0;
+    list-style: none;
+    white-space: nowrap;
+    font-size: 0;
+    height: 16px;
+}
+
+div [id^='notes-'] ul li {
+    position: relative;
+    display: inline-block;
+    height: 16px;
+}
+
+div [id^='notes-'] ul li div {
+    height: 16px;
+    position: absolute;
+    left: 0;
+    border-radius: 8px;
+    width: 100%;
 }
 
 .timeline-header {
     grid-column: 1/1;
-    /*display: flex;*/
-    /*align-content: center;*/
-    /*justify-content: center;*/
-    /*flex-direction: column;*/
+    grid-row: auto/auto;
 }
 
 .timeline-header>div h2,

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -104,13 +104,16 @@ div#notes .note-full {
 }
 
 .timeline {
-    padding: 0 0 60px 0;
+    padding: 0 0 32px 0;
 }
 
+.timeline-time {
+    grid-column: 1/24;
+}
 
-.timelines-time {
+.timeline-time ul {
     position: absolute;
-    padding: 120px 0 0 100px;
+    padding: 8px 0 0 100px;
     margin: 0;
     white-space: nowrap;
     border-bottom: 1px solid #282828;
@@ -118,7 +121,7 @@ div#notes .note-full {
     font-size: 0;
 }
 
-.timelines-time li {
+.timeline-time ul li {
     position: relative;
     top: 6px;
     display: inline-block;
@@ -129,48 +132,94 @@ div#notes .note-full {
     text-indent: -12px;
 }
 
-.timelines-time li:last-child {
+.timeline-time ul li:last-child {
     width: 100px;
 }
 
-.timeline-events {
-    position: absolute;
+.timeline-flows {
+    grid-column: 1/24;
+    grid-row: 1;
+}
+
+.timeline-flows ul {
+    /*position: absolute;*/
     padding: 0 0 0 100px;
     list-style: none;
     white-space: nowrap;
     font-size: 0;
 }
 
-.timeline-events h2,
-.timeline-events h3,
-.timeline-events h4 {
+.timeline-flows ul h2,
+.timeline-flows ul h3,
+.timeline-flows ul h4 {
     margin: 0 0 1px 0;
     font-weight: normal;
     font-size: 11px;
 }
 
-.timeline-events h2 {
+.timeline-flows ul h2 {
     color: #777;
     text-transform: uppercase;
 }
 
-.timeline-events h3 {
+.timeline-flows ul h3 {
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden
 }
 
-.timeline-events h4 {
+.timeline-flows ul h4 {
     color: #fff;
     font-style: italic;
 }
 
-.timeline-events li {
+.timeline-flows li {
     position: relative;
     display: inline-block;
 }
 
-.timeline-events .timeline-event {
+.timeline-events{
+    grid-column: 2/24;
+}
+
+.timeline-events ul{
+    position: absolute;
+    padding: 0 0 0 0;
+    list-style: none;
+    white-space: nowrap;
+    font-size: 0;
+}
+
+.timeline-events ul h2,
+.timeline-events ul h3,
+.timeline-events ul h4 {
+    margin: 0 0 1px 0;
+    font-weight: normal;
+    font-size: 11px;
+}
+
+.timeline-events ul h2 {
+    color: #777;
+    text-transform: uppercase;
+}
+
+.timeline-events ul h3 {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden
+}
+
+.timeline-events ul h4 {
+    color: #fff;
+    font-style: italic;
+}
+
+.timeline-events ul li {
+    position: relative;
+    display: inline-block;
+}
+
+.timeline-events ul .timeline-event {
     position: absolute;
     left: 0;
     height: 8px;
@@ -178,23 +227,28 @@ div#notes .note-full {
     width: 100%;
 }
 
+.timeline-event {
+    opacity: 0.6;
+}
+
 div [id^='timeline-container-'] {
-    height: 80px;
     padding-bottom: 16px;
-    display: flex;
-    flex-direction: row;
+    display: grid;
+    /*flex-direction: row;*/
+    grid-template-columns: repeat(24, 100px);
 }
 
 .timeline-header {
-    display: flex;
-    align-content: center;
-    align-items: center;
-    justify-content: center;
+    grid-column: 1/1;
+    /*display: flex;*/
+    /*align-content: center;*/
+    /*justify-content: center;*/
+    /*flex-direction: column;*/
 }
 
-.timeline-header h2,
-.timeline-header h3,
-.timeline-header h4 {
+.timeline-header>div h2,
+.timeline-header>div h3,
+.timeline-header>div h4 {
     margin: 0 0 1px 0;
     font-weight: normal;
     font-size: 14px;

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -99,7 +99,9 @@ div#notes .note-full {
 }
 
 
-
+.timeline-controls {
+    padding-bottom: 12px;
+}
 
 
 .timelines-years {
@@ -155,4 +157,21 @@ div#notes .note-full {
 div [id^='timeline-container-'] {
     height: 80px;
     padding-bottom: 16px;
+    display: flex;
+    flex-direction: row;
+}
+
+.timeline-header {
+    display: flex;
+    align-content: center;
+    align-items: center;
+    justify-content: center;
+}
+
+.timeline-header h2,
+.timeline-header h3,
+.timeline-header h4 {
+    margin: 0 0 1px 0;
+    font-weight: normal;
+    font-size: 14px;
 }

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -182,12 +182,12 @@ div#notes .note-full {
     display: inline-block;
 }
 
-.timeline-events{
+.timeline-events {
     grid-row: auto / auto;
     grid-column: 2/24;
 }
 
-.timeline-events ul{
+.timeline-events ul {
     position: absolute;
     padding: 0 0 0 0;
     list-style: none;
@@ -274,10 +274,38 @@ div [id^='notes-'] ul li div {
     grid-row: auto/auto;
 }
 
-.timeline-header>div h2,
-.timeline-header>div h3,
-.timeline-header>div h4 {
+.timeline-header > div h2,
+.timeline-header > div h3,
+.timeline-header > div h4 {
     margin: 0 0 1px 0;
     font-weight: normal;
     font-size: 14px;
+}
+
+.c-dialog {
+    position: fixed;
+    z-index: 100;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    display: flex;
+    padding: 2.4rem;
+    overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
+    background-color: rgba(0, 0, 0, .75);
+    transition: .2s;
+}
+
+.c-dialog__box {
+    flex: 1;
+    max-width: 48rem;
+    margin: auto;
+    padding: 2.4rem;
+    background-color: white;
+}
+
+.c-dialog[aria-hidden="true"] {
+    visibility: hidden;
+    opacity: 0;
 }

--- a/ui/src/timeline.js
+++ b/ui/src/timeline.js
@@ -6,7 +6,6 @@ import { drawSummary } from './summary.js';
 import { dom, clearElement } from './dom.js';
 import { config } from "./config";
 import { colorOf } from './color.js';
-import {LocalDate, LocalDateTime} from "@js-joda/core";
 
 /**
    Draw a timeline chart in given element with given data

--- a/ui/src/timeline.js
+++ b/ui/src/timeline.js
@@ -65,10 +65,10 @@ function createTimelineContainer(day, data, notesData) {
   details.addEventListener('change', (e) => {
     if (e.target.checked) {
       // drawChart(chart, day, data, f => f.flowType);
-      drawTimeline(chart2, day, data);
+      drawTimeline(chart2, day, config.userProfile.userStartOfDay, config.userProfile.userEndOfDay, data);
     } else {
       // drawChart(chart, day, data);
-      drawTimeline(chart2, day, data);
+      drawTimeline(chart2, day, config.userProfile.userStartOfDay, config.userProfile.userEndOfDay, data);
     }
   });
 
@@ -102,7 +102,7 @@ function createTimelineContainer(day, data, notesData) {
 
   document.getElementById('timelines').appendChild(container);
   // drawChart(chart, day, data);
-  drawTimeline(chart2, day, data);
+  drawTimeline(chart2, day, config.userProfile.userStartOfDay, config.userProfile.userEndOfDay, data);
 }
 
 /**

--- a/ui/src/timeline.js
+++ b/ui/src/timeline.js
@@ -64,8 +64,10 @@ function createTimelineContainer(day, data, notesData) {
   details.addEventListener('change', (e) => {
     if (e.target.checked) {
       drawChart(chart, day, data, f => f.flowType);
+      drawTimeline(chart2, data);
     } else {
       drawChart(chart, day, data);
+      drawTimeline(chart2, data);
     }
   });
 
@@ -99,6 +101,7 @@ function createTimelineContainer(day, data, notesData) {
 
   document.getElementById('timelines').appendChild(container);
   drawChart(chart, day, data);
+  drawTimeline(chart2, data);
 }
 
 /**

--- a/ui/src/timeline.js
+++ b/ui/src/timeline.js
@@ -57,7 +57,13 @@ function createTimelineContainer(day, data, notesData) {
                 drawCssNotes(chart, day, notesData);
             });
         } else {
-            document.getElementById("timeline-container-" + day).removeChild(document.getElementById("notes-" + day));
+            document.getElementById("notes-" + day).remove();
+            const regExp = new RegExp('^note-' + day + '.*$');
+            Array.from(document.body.childNodes).forEach(node => {
+                if(node.id !== undefined && regExp.test(node.id)) {
+                    node.remove();
+                }
+            });
         }
     });
 

--- a/ui/src/timeline.js
+++ b/ui/src/timeline.js
@@ -1,138 +1,117 @@
-import { get } from './request.js';
-import { formatISODate } from './date.js';
-import { drawNotes } from './notes.js';
-import { drawCommands } from './commands.js';
-import { drawSummary } from './summary.js';
-import { dom, clearElement } from './dom.js';
-import { config } from "./config";
-import { colorOf } from './color.js';
+import {get} from './request.js';
+import {formatISODate} from './date.js';
+import {drawNotes} from './notes.js';
+import {drawCommands} from './commands.js';
+import {drawSummary} from './summary.js';
+import {dom, clearElement} from './dom.js';
+import {config} from "./config";
+import {colorOf} from './color.js';
 import {drawTimeline} from "./css-timeline.js";
+import {drawCssNotes} from "./css-notes.js";
 import {LocalDate, LocalDateTime} from "@js-joda/core";
 
 /**
-   Draw a timeline chart in given element with given data
-*/
-function drawChart(container, selectedDate, flowData, rowLabelling = (_ => selectedDate)) {
-  const chart = new google.visualization.Timeline(container);
-  const dataTable = new google.visualization.DataTable();
-
-  dataTable.addColumn({ type: 'string', id: 'Role' });
-  dataTable.addColumn({ type: 'string', id: 'Flow Type' });
-  dataTable.addColumn({ type: 'string', id: 'style', role: 'style' });
-  dataTable.addColumn({ type: 'date', id: 'Start' });
-  dataTable.addColumn({ type: 'date', id: 'End' });
-  flowData.forEach(flow =>
-    dataTable.addRow([rowLabelling(flow), flow.flowType, colorOf(flow.flowType), new Date(flow.flowStart), new Date(flow.flowEnd)])
-  );
-  chart.draw(dataTable);
-}
-
-/**
-   Create a new div container for a timeline
-*/
+ Create a new div container for a timeline
+ */
 function createTimelineContainer(day, data, notesData) {
-  const detailsName = 'checkbox-' + day;
-  const notesName = 'notes-checkbox-' + day;
-  const commandsName = 'cmd-checkbox-' + day;
-  const summaryName = 'summary-checkbox-' + day;
-  const chart = <div id={'chart-' + day} class="timeline-chart" />;
-  const notesDiv = <div id={'notes-' + day} class="timeline-chart" />;
-  const commandsDiv = <div id={'commands-' + day} class="timeline-chart" />;
-  const summaryDiv = <div id={'summary-' + day} class="summary" />;
-  const details = <input type="checkbox" id={detailsName} />;
-  const notes = <input type="checkbox" id={notesName} />;
-  const commands = <input type="checkbox" id={commandsName} />;
-  const summary = <input type="checkbox" id={summaryName} />;
+    const detailsName = 'checkbox-' + day;
+    const notesName = 'notes-checkbox-' + day;
+    const commandsName = 'cmd-checkbox-' + day;
+    const summaryName = 'summary-checkbox-' + day;
+    const chart = <div class="timeline-chart"/>;
+    const commandsDiv = <div id={'commands-' + day} class="timeline-chart"/>;
+    const summaryDiv = <div id={'summary-' + day} class="summary"/>;
+    const details = <input type="checkbox" id={detailsName}/>;
+    const notes = <input type="checkbox" id={notesName}/>;
+    const commands = <input type="checkbox" id={commandsName}/>;
+    const summary = <input type="checkbox" id={summaryName}/>;
 
-  const container =
-    <div id={day} class='timeline'>
-      <div class='timeline-controls'>
-        <label for={detailsName}>Expand</label>
-        {details}
-        <label for={notesName}>Notes</label>
-        {notes}
-        <label for={commandsName}>Commands</label>
-        {commands}
-        <label for={summaryName}>Summary</label>
-        {summary}
-      </div>
-      {chart}
-      {notesDiv}
-      {commandsDiv}
-      {summaryDiv}
-    </div>;
+    const container =
+        <div id={day} class='timeline'>
+            <div class='timeline-controls'>
+                <label for={detailsName}>Expand</label>
+                {details}
+                <label for={notesName}>Notes</label>
+                {notes}
+                <label for={commandsName}>Commands</label>
+                {commands}
+                <label for={summaryName}>Summary</label>
+                {summary}
+            </div>
+            {commandsDiv}
+            {summaryDiv}
+            {chart}
+        </div>;
 
-  details.addEventListener('change', (e) => {
-    if (e.target.checked) {
-      // drawChart(chart, day, data, f => f.flowType);
-      drawTimeline(chart2, day, data, f => f.flowType);
-    } else {
-      // drawChart(chart, day, data);
-      drawTimeline(chart2, day, data);
-    }
-  });
+    details.addEventListener('change', (e) => {
+        if (e.target.checked) {
+            drawTimeline(chart, day, data, f => f.flowType);
+        } else {
+            drawTimeline(chart, day, data);
+        }
+    });
 
-  notes.addEventListener('change', (e) => {
-    if (e.target.checked) {
-      get(`/api/flows/${config.user}/${day}/notes`, (notesData) =>
-        drawNotes(notesDiv, notesData));
-    } else {
-      clearElement(notesDiv);
-    }
-  });
+    notes.addEventListener('change', (e) => {
+        if (e.target.checked) {
+            get(`/api/flows/${config.user}/${day}/notes`, (notesData) => {
+                drawCssNotes(chart, day, notesData);
+            });
+        } else {
+            document.getElementById("timeline-container-" + day).removeChild(document.getElementById("notes-" + day));
+        }
+    });
 
-  commands.addEventListener('change', (e) => {
-    if (e.target.checked) {
-      get(`/api/flows/${config.user}/${day}/commands`, (commandsData) =>
-        drawCommands(commandsDiv, commandsData));
-    } else {
-      clearElement(commandsDiv);
-    }
-  });
+    commands.addEventListener('change', (e) => {
+        if (e.target.checked) {
+            get(`/api/flows/${config.user}/${day}/commands`, (commandsData) =>
+                drawCommands(commandsDiv, commandsData));
+        } else {
+            clearElement(commandsDiv);
+        }
+    });
 
 
-  summary.addEventListener('change', (e) => {
-    if (e.target.checked) {
-      get(`/api/flows/${config.user}/${day}/summary`, (summaryData) =>
-        drawSummary(summaryDiv, summaryData));
-    } else {
-      clearElement(summaryDiv);
-    }
-  });
+    summary.addEventListener('change', (e) => {
+        if (e.target.checked) {
+            get(`/api/flows/${config.user}/${day}/summary`, (summaryData) =>
+                drawSummary(summaryDiv, summaryData));
+        } else {
+            clearElement(summaryDiv);
+        }
+    });
 
-  document.getElementById('timelines').appendChild(container);
-  // drawChart(chart, day, data);
-  drawTimeline(chart2, day, data);
+    document.getElementById('timelines').appendChild(container);
+    drawTimeline(chart, day, data);
 }
 
 /**
-   Draw several timeline charts within the `timelines` container, each for a different
-   data
-   For now, we assume the data is a list of days
-*/
+ Draw several timeline charts within the `timelines` container, each for a different
+ data
+ For now, we assume the data is a list of days
+ */
 function drawCharts(flowData) {
-  flowData.forEach((f) => {
-    const day = formatISODate(LocalDateTime.parse(f.groupTime));
-    const data = f.subGroup.leafViews;
-    createTimelineContainer(day, data);
-  });
+    flowData.forEach((f) => {
+        const day = formatISODate(LocalDateTime.parse(f.groupTime));
+        const data = f.subGroup.leafViews;
+        createTimelineContainer(day, data);
+    });
 }
 
 function fetchFlowData(selectedDate) {
-  get(`/api/flows/${config.user}/` + selectedDate, (flowData) => {
-    createTimelineContainer(selectedDate, flowData);
-  });
+    get(`/api/flows/${config.user}/` + selectedDate, (flowData) => {
+        createTimelineContainer(selectedDate, flowData);
+    });
 };
 
 function fetchAllFlowData() {
-  get(`/api/flows/${config.user}?group=Day`, drawCharts);
+    get(`/api/flows/${config.user}?group=Day`, drawCharts);
 };
 
 export default function timeline() {
-  const obj = {};
+    const obj = {};
 
-  obj.fetchFlowData = fetchFlowData;
-  obj.fetchAllFlowData = fetchAllFlowData;
+    obj.fetchFlowData = fetchFlowData;
+    obj.fetchAllFlowData = fetchAllFlowData;
 
-  return obj;
+    return obj;
 }

--- a/ui/src/timeline.js
+++ b/ui/src/timeline.js
@@ -63,11 +63,11 @@ function createTimelineContainer(day, data, notesData) {
 
   details.addEventListener('change', (e) => {
     if (e.target.checked) {
-      drawChart(chart, day, data, f => f.flowType);
-      drawTimeline(chart2, data);
+      // drawChart(chart, day, data, f => f.flowType);
+      drawTimeline(chart2, day, data);
     } else {
-      drawChart(chart, day, data);
-      drawTimeline(chart2, data);
+      // drawChart(chart, day, data);
+      drawTimeline(chart2, day, data);
     }
   });
 
@@ -100,8 +100,8 @@ function createTimelineContainer(day, data, notesData) {
   });
 
   document.getElementById('timelines').appendChild(container);
-  drawChart(chart, day, data);
-  drawTimeline(chart2, data);
+  // drawChart(chart, day, data);
+  drawTimeline(chart2, day, data);
 }
 
 /**

--- a/ui/src/timeline.js
+++ b/ui/src/timeline.js
@@ -6,6 +6,8 @@ import { drawSummary } from './summary.js';
 import { dom, clearElement } from './dom.js';
 import { config } from "./config";
 import { colorOf } from './color.js';
+import {drawTimeline} from "./css-timeline.js";
+import {LocalDate, LocalDateTime} from "@js-joda/core";
 
 /**
    Draw a timeline chart in given element with given data

--- a/ui/src/timeline.js
+++ b/ui/src/timeline.js
@@ -65,10 +65,10 @@ function createTimelineContainer(day, data, notesData) {
   details.addEventListener('change', (e) => {
     if (e.target.checked) {
       // drawChart(chart, day, data, f => f.flowType);
-      drawTimeline(chart2, day, config.userProfile.userStartOfDay, config.userProfile.userEndOfDay, data, f => f.flowStart);
+      drawTimeline(chart2, day, data, f => f.flowType);
     } else {
       // drawChart(chart, day, data);
-      drawTimeline(chart2, day, config.userProfile.userStartOfDay, config.userProfile.userEndOfDay, data);
+      drawTimeline(chart2, day, data);
     }
   });
 
@@ -102,7 +102,7 @@ function createTimelineContainer(day, data, notesData) {
 
   document.getElementById('timelines').appendChild(container);
   // drawChart(chart, day, data);
-  drawTimeline(chart2, day, config.userProfile.userStartOfDay, config.userProfile.userEndOfDay, data);
+  drawTimeline(chart2, day, data);
 }
 
 /**

--- a/ui/src/timeline.js
+++ b/ui/src/timeline.js
@@ -64,10 +64,10 @@ function createTimelineContainer(day, data, notesData) {
   details.addEventListener('change', (e) => {
     if (e.target.checked) {
       // drawChart(chart, day, data, f => f.flowType);
-      drawTimeline(chart2, day, config.userProfile.userStartOfDay, config.userProfile.userEndOfDay, data);
+      drawTimeline(chart2, day, data);
     } else {
       // drawChart(chart, day, data);
-      drawTimeline(chart2, day, config.userProfile.userStartOfDay, config.userProfile.userEndOfDay, data);
+      drawTimeline(chart2, day, data);
     }
   });
 
@@ -101,7 +101,7 @@ function createTimelineContainer(day, data, notesData) {
 
   document.getElementById('timelines').appendChild(container);
   // drawChart(chart, day, data);
-  drawTimeline(chart2, day, config.userProfile.userStartOfDay, config.userProfile.userEndOfDay, data);
+  drawTimeline(chart2, day, data);
 }
 
 /**

--- a/ui/src/timeline.js
+++ b/ui/src/timeline.js
@@ -58,9 +58,10 @@ function createTimelineContainer(day, data, notesData) {
             });
         } else {
             document.getElementById("notes-" + day).remove();
+            document.getElementById('title-notes-' + day).remove();
             const regExp = new RegExp('^note-' + day + '.*$');
             Array.from(document.body.childNodes).forEach(node => {
-                if(node.id !== undefined && regExp.test(node.id)) {
+                if (node.id !== undefined && regExp.test(node.id)) {
                     node.remove();
                 }
             });

--- a/ui/src/timeline.js
+++ b/ui/src/timeline.js
@@ -64,10 +64,10 @@ function createTimelineContainer(day, data, notesData) {
   details.addEventListener('change', (e) => {
     if (e.target.checked) {
       // drawChart(chart, day, data, f => f.flowType);
-      drawTimeline(chart2, day, data);
+      drawTimeline(chart2, day, config.userProfile.userStartOfDay, config.userProfile.userEndOfDay, data);
     } else {
       // drawChart(chart, day, data);
-      drawTimeline(chart2, day, data);
+      drawTimeline(chart2, day, config.userProfile.userStartOfDay, config.userProfile.userEndOfDay, data);
     }
   });
 
@@ -101,7 +101,7 @@ function createTimelineContainer(day, data, notesData) {
 
   document.getElementById('timelines').appendChild(container);
   // drawChart(chart, day, data);
-  drawTimeline(chart2, day, data);
+  drawTimeline(chart2, day, config.userProfile.userStartOfDay, config.userProfile.userEndOfDay, data);
 }
 
 /**

--- a/ui/src/timeline.js
+++ b/ui/src/timeline.js
@@ -65,7 +65,7 @@ function createTimelineContainer(day, data, notesData) {
   details.addEventListener('change', (e) => {
     if (e.target.checked) {
       // drawChart(chart, day, data, f => f.flowType);
-      drawTimeline(chart2, day, config.userProfile.userStartOfDay, config.userProfile.userEndOfDay, data);
+      drawTimeline(chart2, day, config.userProfile.userStartOfDay, config.userProfile.userEndOfDay, data, f => f.flowStart);
     } else {
       // drawChart(chart, day, data);
       drawTimeline(chart2, day, config.userProfile.userStartOfDay, config.userProfile.userEndOfDay, data);


### PR DESCRIPTION
In this pull request, you have:
- the display of the timeline for flows (linear and expand) and notes
- the tests based on snapshots (which are not very easy sometime to maintain) with the snapshots results
TODO:
- the display of the summary
- the display of the commands
- we play a lot with the dom between notes and timeline, the flows, notes, summaries and command are inside the container of the timeline and on each event we prevent from redrawing the header (containing the schedule of the day with the different flow types) and the footer (containing the line with the hours of the day). We should avoid that by providing on each event the body of the timeline we want to adapt instead of all.

Sorry for the huge pull request that has all the commits since december and the time I took to draw this timeline 